### PR TITLE
test: optimization fork and add windows

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [16, 18]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
     - name: Checkout Git Source

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout Git Source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3

--- a/src/core/trigger.ts
+++ b/src/core/trigger.ts
@@ -53,9 +53,12 @@ export class CommandTrigger extends Trigger {
     }
 
     this.binInfo = {
-      ...pkgInfo,
+      name: pkgInfo.name,
+      version: pkgInfo.version,
+      description: pkgInfo.description,
       binName: config.binName,
       baseDir: config.baseDir,
+      pkgInfo,
     };
 
     this.use(async (ctx: CommandContext, next) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,11 +40,11 @@ export interface CommonBinConfig {
 }
 
 export interface CommonBinInfo {
-  binName: string;
-  baseDir: string;
   name: string;
   version?: string;
+  binName: string;
+  baseDir: string;
   author?: string;
   description?: string;
-  homepage?: string;
+  pkgInfo?: Record<string, any>;
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,15 +1,8 @@
-import coffee from 'coffee';
-import path from 'path';
+import { fork } from './utils';
 
 describe('test', () => {
-  const tsNode = path.resolve(__dirname, '../node_modules/.bin/ts-node');
-  const eggBin = path.resolve(__dirname, './fixtures/egg-bin/bin.ts');
-  const chairBin = path.resolve(__dirname, './fixtures/chair-bin/bin.ts');
-  const simpleBin = path.resolve(__dirname, './fixtures/simple-bin/bin.ts');
-  const overrideBin = path.resolve(__dirname, './fixtures/override/bin.ts');
-
   it('egg-bin should work', async () => {
-    await coffee.fork(tsNode, [ eggBin, '--help' ])
+    await fork('egg-bin', [ '--help' ])
       .debug()
       .expect('stdout', /Usage: egg-bin/)
       .expect('stdout', /Available Commands/)
@@ -20,7 +13,7 @@ describe('test', () => {
       .expect('stdout', /-v, --version    Show Version/)
       .end();
 
-    await coffee.fork(tsNode, [ eggBin, 'dev', '123', '-p=6000' ])
+    await fork('egg-bin', [ 'dev', '123', '-p=6000' ])
       .debug()
       .expect('stdout', /port 6000/)
       .expect('stdout', /egg-bin dev command prerun/)
@@ -30,12 +23,12 @@ describe('test', () => {
       .expect('stdout', /baseDir 123/)
       .end();
 
-    await coffee.fork(tsNode, [ eggBin, '-v' ])
+    await fork('egg-bin', [ '-v' ])
       .debug()
       .expect('stdout', /1.0.0/)
       .end();
 
-    await coffee.fork(tsNode, [ eggBin, 'dev', '-h' ])
+    await fork('egg-bin', [ 'dev', '-h' ])
       .debug()
       .expect('stdout', /Run the development server/)
       .expect('stdout', /dev \[baseDir\]   Run the development server/)
@@ -43,14 +36,14 @@ describe('test', () => {
       .expect('stdout', /--inspect             Debug with node-inspector/)
       .end();
 
-    await coffee.fork(tsNode, [ eggBin, 'test', './', 'file1', 'file2' ])
+    await fork('egg-bin', [ 'test', './', 'file1', 'file2' ])
       .debug()
       .expect('stdout', /test command middleware 1\ntest command middleware 2\ntest command middleware 3/)
       .expect('stdout', /test baseDir .\//)
       .expect('stdout', /test files \[ 'file1', 'file2' \]/)
       .end();
 
-    await coffee.fork(tsNode, [ eggBin, 'cov', './', 'file1', 'file2', '--c8=true' ])
+    await fork('egg-bin', [ 'cov', './', 'file1', 'file2', '--c8=true' ])
       .debug()
       .expect('stdout', /coverage c8 true/)
       .expect('stdout', /test command middleware 1\ntest command middleware 2\ntest command middleware 3/)
@@ -60,7 +53,7 @@ describe('test', () => {
   });
 
   it('egg-bin should work with different env', async () => {
-    await coffee.fork(tsNode, [ eggBin, '--help' ], {
+    await fork('egg-bin', [ '--help' ], {
       env: { ...process.env, ARTUS_CLI_ENV: 'prod' },
     })
       .debug()
@@ -69,7 +62,7 @@ describe('test', () => {
   });
 
   it('chair-bin should work', async () => {
-    await coffee.fork(tsNode, [ chairBin, '--help' ])
+    await fork('chair-bin', [ '--help' ])
       .debug()
       .expect('stdout', /Usage: chair-bin/)
       .expect('stdout', /Available Commands/)
@@ -87,7 +80,7 @@ describe('test', () => {
       .expect('stdout', /-v, --version    Show Version/)
       .end();
 
-    await coffee.fork(tsNode, [ chairBin, 'dev', '123', '-p=6000' ])
+    await fork('chair-bin', [ 'dev', '123', '-p=6000' ])
       .debug()
       .expect('stdout', /port 6000/)
       .expect('stdout', /egg-bin dev command prerun\nchair-bin dev command prerun/)
@@ -97,54 +90,54 @@ describe('test', () => {
       .expect('stdout', /baseDir 123/)
       .end();
 
-    await coffee.fork(tsNode, [ chairBin, 'codegen' ])
+    await fork('chair-bin', [ 'codegen' ])
       .debug()
       .expect('stdout', /run codegen in codegen plugin/)
       .end();
 
-    await coffee.fork(tsNode, [ chairBin, 'cg' ])
+    await fork('chair-bin', [ 'cg' ])
       .debug()
       .expect('stdout', /run codegen in codegen plugin/)
       .end();
 
-    await coffee.fork(tsNode, [ chairBin, 'cg', 'ex' ])
+    await fork('chair-bin', [ 'cg', 'ex' ])
       .debug()
       .expect('stdout', /run extra codegen in codegen extra/)
       .end();
 
-    await coffee.fork(tsNode, [ chairBin, 'module', 'dev', './' ])
+    await fork('chair-bin', [ 'module', 'dev', './' ])
       .debug()
       .notExpect('stdout', /chair-bin dev command prerun/)
       .expect('stdout', /module is dev in .\//)
       .end();
 
-    await coffee.fork(tsNode, [ chairBin, 'oneapi', 'client', 'app' ])
+    await fork('chair-bin', [ 'oneapi', 'client', 'app' ])
       .debug()
       .expect('stdout', /oneapi client app/)
       .end();
 
-    await coffee.fork(tsNode, [ chairBin, 'user', '-u=123' ])
+    await fork('chair-bin', [ 'user', '-u=123' ])
       .debug()
       .expect('stdout', /user is foo/)
       .end();
   });
 
   it('simple-bin should work', async () => {
-    await coffee.fork(tsNode, [ simpleBin, '--help' ])
+    await fork('simple-bin', [ '--help' ])
       .debug()
       .expect('stdout', /Usage: simple-bin \[baseDir\]/)
       .expect('stdout', /-p, --port number   port/)
       .expect('stdout', /-h, --help          Show Help/)
       .end();
 
-    await coffee.fork(tsNode, [ simpleBin, './src', '--port', '7001' ])
+    await fork('simple-bin', [ './src', '--port', '7001' ])
       .debug()
       .expect('stdout', /Run with port 7001 in \.\/src/)
       .end();
   });
 
   it('override-bin should work', async () => {
-    await coffee.fork(tsNode, [ overrideBin, 'dev' ])
+    await fork('override', [ 'dev' ])
       .debug()
       .expect('stdout', /extractly override/)
       .end();

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,15 @@
+import path from 'path';
+import coffee from 'coffee';
+import { ForkOptions } from 'child_process';
+
+export function fork(target: string, args?: string[], options?: ForkOptions) {
+  // const env = { ...process.env, TS_NODE_PROJECT: './test/tsconfig.json' };
+  // or use coffee.beforeScript to register ts-node
+  // TODO: refactor to clet
+  const bin = path.join(__dirname, 'fixtures', target, 'bin.ts');
+  return coffee.fork(bin, args, {
+    cwd: __dirname,
+    execArgv: [ '-r', 'ts-node/register' ],
+    ...options,
+  });
+}


### PR DESCRIPTION
pnpm 似乎安装的 bin 会包一层 shell，导致 coffee.fork 会出问题，因为 shell 只能用 coffee.spawn

改为直接 fork 对应的 bin，然后通过 execArgv 的方式注入 ts-node，这样更简单。