### PR TITLE
refactor: init meta in tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "types": "dist/index.d.ts",
   "type": "commonjs",
   "scripts": {
-    "lint": "eslint . --ext .ts && tsc --noEmit",
+    "lint": "eslint . --ext .ts",
+    "postlint": "tsc --noEmit",
     "test": "cross-env TS_NODE_PROJECT=test/tsconfig.json mocha",
     "cov": "c8 -n src/ npm test",
     "ci": "npm run cov",
@@ -28,7 +29,7 @@
     "lodash.omit": "^4.5.0",
     "lodash.pick": "^4.4.0",
     "reflect-metadata": "^0.1.13",
-    "type-fest": "^3.3.0",
+    "type-fest": "^3.4.0",
     "yargs-parser": "^21.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "c8": "^7.12.0",
     "coffee": "^5.5.0",
     "cross-env": "^7.0.3",
-    "dirname-filename-esm": "^1.1.1",
     "eslint": "^8.28.0",
     "inquirer": "^8.0.0",
     "mocha": "^10.0.0",

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -6,7 +6,7 @@ const RAW_SYMBOL = Symbol('CommandContext#raw');
 export interface CommandInput {
   params: {
     argv: string[];
-    env: Record<string, string>;
+    env: Record<string, string | undefined>;
     cwd: string;
   };
 }
@@ -31,7 +31,7 @@ export class CommandContext<
   /** matched result */
   private matchResult: MatchResult;
 
-  env: Record<string, string>;
+  env: Record<string, string | undefined>;
   cwd: string;
   input: CommandInput;
   output: CommandOutput<OutputResult>;

--- a/src/core/decorators.ts
+++ b/src/core/decorators.ts
@@ -89,7 +89,7 @@ export function Middleware(fn: MiddlewareInput, option?: MiddlewareDecoratorOpti
 
     if (typeof option?.override === 'boolean') {
       if (typeof existsMeta.override === 'boolean' && existsMeta.override !== option.override) {
-        throw new Error(`Cannot config override in multiple @Middleware`);
+        throw new Error(`Can\'t use override in multiple @Middleware`);
       }
 
       existsMeta.override = true;

--- a/src/core/decorators.ts
+++ b/src/core/decorators.ts
@@ -91,7 +91,7 @@ export function Middleware(fn: MiddlewareInput, option?: MiddlewareDecoratorOpti
       throw new Error(`Can\'t use override in multiple @Middleware`);
     }
 
-    existsMeta.override = !!option?.override;
+    existsMeta.override = option?.override;
     Reflect.defineMetadata(metaKey, existsMeta, ctor);
   };
 }

--- a/src/core/decorators.ts
+++ b/src/core/decorators.ts
@@ -5,35 +5,27 @@ import { CommandContext, CommandOutput } from './context';
 import compose from 'koa-compose';
 import { Command } from './command';
 import { checkCommandCompatible } from '../utils';
-import { MiddlewareInput, Middlewares } from '@artus/pipeline';
-import { CommandProps, OptionProps, OptionMeta, CommandMeta } from '../types';
+import { MiddlewareMeta, MiddlewareInput, MiddlewareConfig, CommandConfig, OptionProps, OptionMeta, CommandMeta, OptionConfig } from '../types';
 
 export interface CommonDecoratorOption {
   /** whether merge meta info of prototype */
   override?: boolean;
 }
 
-export interface MiddlewareDecoratorOption extends CommonDecoratorOption {
-  /** default is after */
-  mergeType?: 'before' | 'after'
+export interface MiddlewareDecoratorOption extends CommonDecoratorOption, Pick<MiddlewareConfig, 'mergeType'> {
+  // nothing
 }
 
 export function DefineCommand(
-  opt?: CommandProps,
+  opt?: CommandConfig,
   option?: CommonDecoratorOption,
 ) {
   return <T extends typeof Command>(target: T) => {
-    let meta: CommandMeta = { ...opt };
+    Reflect.defineMetadata(MetadataEnum.COMMAND, {
+      config: opt || {},
+      override: option?.override,
+    }, target);
 
-    // merge meta of prototype
-    if (!option?.override) {
-      const protoMeta = Reflect.getMetadata(MetadataEnum.COMMAND, Object.getPrototypeOf(target));
-      meta = Object.assign({}, protoMeta, meta);
-    }
-
-    // default command is main command
-    meta.command = meta.command || '$0';
-    Reflect.defineMetadata(MetadataEnum.COMMAND, meta, target);
     addTag(MetadataEnum.COMMAND, target);
     Injectable({ scope: ScopeEnum.EXECUTION })(target);
 
@@ -49,12 +41,6 @@ export function DefineOption<T extends object = object>(
   return <G extends Command>(target: G, key: string) => {
     const ctor = target.constructor as typeof Command;
 
-    // merge meta of prototype
-    if (!option?.override) {
-      const protoMeta = Reflect.getMetadata(MetadataEnum.OPTION, Object.getPrototypeOf(ctor));
-      meta = Object.assign({}, protoMeta?.meta, meta);
-    }
-
     // define option key
     const keySymbol = Symbol(`${ctor.name}#${key}`);
     Object.defineProperty(ctor.prototype, key, {
@@ -67,7 +53,7 @@ export function DefineOption<T extends object = object>(
         const parsedCommands = ctx.container.get(ParsedCommands);
         const targetCommand = parsedCommands.getCommand(ctor);
         // check target command whether is compatible with matched
-        const isSameCommandOrCompatible = matched.clz === ctor || checkCommandCompatible(targetCommand, matched);
+        const isSameCommandOrCompatible = matched?.clz === ctor || (matched && targetCommand && checkCommandCompatible(targetCommand, matched));
         this[keySymbol] = isSameCommandOrCompatible ? args : parsedCommands.parseArgs(argv, targetCommand);
         return this[keySymbol];
       },
@@ -78,9 +64,10 @@ export function DefineOption<T extends object = object>(
       },
     });
 
+    const config = (meta || {}) as OptionConfig;
     Reflect.defineMetadata(
       MetadataEnum.OPTION,
-      { key, meta } satisfies OptionMeta,
+      { key, config, override: option?.override } satisfies OptionMeta,
       ctor,
     );
   };
@@ -92,35 +79,25 @@ export function Middleware(fn: MiddlewareInput, option?: MiddlewareDecoratorOpti
 
     const ctor = key ? target.constructor : target;
     const metaKey = key ? MetadataEnum.RUN_MIDDLEWARE : MetadataEnum.MIDDLEWARE;
-    const fns = (Array.isArray(fn) ? fn : [ fn ]) as Middlewares;
-    let existsFns: Middlewares = Reflect.getOwnMetadata(metaKey, ctor);
+    const existsMeta: MiddlewareMeta = Reflect.getOwnMetadata(metaKey, ctor) || ({ configList: [] });
 
-    // merge meta of prototype, only works in class
-    if (!key && !existsFns) {
-      const protoMeta = Reflect.getMetadata(MetadataEnum.MIDDLEWARE, Object.getPrototypeOf(ctor));
-      existsFns = protoMeta;
-    }
+    // add config in meta data
+    existsMeta.configList.push({
+      middleware: fn,
+      mergeType: option?.mergeType || 'after',
+    });
 
-    existsFns = option?.override ? [] : (existsFns || []);
+    if (typeof option?.override === 'boolean') {
+      if (typeof existsMeta.override === 'boolean' && existsMeta.override !== option.override) {
+        throw new Error(`Cannot config override in multiple @Middleware`);
+      }
 
-    // Default orders:
-    //
-    // In class inheritance:
-    //              command1  <-extend-  command2
-    // trigger --> middleware1   -->   middleware2 --> middleware3  --> run
-    //
-    // ------------
-    //
-    // In run method:
-    //                      command2                               command1
-    // trigger --> middleware2 --> middleware3 --> run --> middleware1 --> super.run
-    if (!option?.mergeType || option?.mergeType === 'after') {
-      existsFns = existsFns.concat(fns);
+      existsMeta.override = true;
     } else {
-      existsFns = fns.concat(existsFns);
+      existsMeta.override = false;
     }
 
-    Reflect.defineMetadata(metaKey, existsFns, ctor);
+    Reflect.defineMetadata(metaKey, existsMeta, ctor);
   };
 }
 
@@ -136,10 +113,11 @@ function wrapWithMiddleware(clz) {
   Object.defineProperty(clz.prototype, 'run', {
     async value(...args: any[]) {
       const ctx: CommandContext = this[CONTEXT_SYMBOL];
+      const parsedCommand = ctx.container.get(ParsedCommands).getCommand(clz);
+
       // compose with middlewares in run method
-      const middlewares = Reflect.getOwnMetadata(MetadataEnum.RUN_MIDDLEWARE, clz) || [];
       return await compose([
-        ...middlewares,
+        ...parsedCommand?.executionMiddlewares || [],
         async (ctx: CommandContext) => {
           const result = await runMethod.apply(this, args);
           ctx.output.data = { result } satisfies CommandOutput['data'];
@@ -153,10 +131,11 @@ function wrapWithMiddleware(clz) {
   Object.defineProperty(clz.prototype, EXCUTION_SYMBOL, {
     async value(...args: any[]) {
       const ctx: CommandContext = this[CONTEXT_SYMBOL];
+      const parsedCommand = ctx.container.get(ParsedCommands).getCommand(clz);
+
       // compose with middlewares in Command Class
-      const middlewares = Reflect.getMetadata(MetadataEnum.MIDDLEWARE, clz) || [];
       return await compose([
-        ...middlewares,
+        ...parsedCommand?.commandMiddlewares || [],
         async () => this.run(...args),
       ])(ctx);
     },

--- a/src/core/decorators.ts
+++ b/src/core/decorators.ts
@@ -35,7 +35,7 @@ export function DefineCommand(
 }
 
 export function DefineOption<T extends object = object>(
-  meta?: { [P in keyof T]?: OptionProps; },
+  meta?: { [P in keyof Omit<T, '_' | '--'>]?: OptionProps; },
   option?: CommonDecoratorOption,
 ) {
   return <G extends Command>(target: G, key: string) => {

--- a/src/core/decorators.ts
+++ b/src/core/decorators.ts
@@ -87,16 +87,11 @@ export function Middleware(fn: MiddlewareInput, option?: MiddlewareDecoratorOpti
       mergeType: option?.mergeType || 'after',
     });
 
-    if (typeof option?.override === 'boolean') {
-      if (typeof existsMeta.override === 'boolean' && existsMeta.override !== option.override) {
-        throw new Error(`Can\'t use override in multiple @Middleware`);
-      }
-
-      existsMeta.override = true;
-    } else {
-      existsMeta.override = false;
+    if (typeof option?.override === 'boolean' && typeof existsMeta.override === 'boolean' && existsMeta.override !== option.override) {
+      throw new Error(`Can\'t use override in multiple @Middleware`);
     }
 
+    existsMeta.override = !!option?.override;
     Reflect.defineMetadata(metaKey, existsMeta, ctor);
   };
 }

--- a/src/core/parsed_commands.ts
+++ b/src/core/parsed_commands.ts
@@ -271,11 +271,11 @@ export class ParsedCommandTree {
     // split options with argument key and merge option info with inherit command
     const optionMeta: OptionMeta | undefined = Reflect.getOwnMetadata(MetadataEnum.OPTION, clz);
     const argumentsKey = parsedCommandInfo.demanded.concat(parsedCommandInfo.optional).map(pos => pos.cmd);
-    const flagOptions: OptionConfig = omit(optionMeta?.config || {}, argumentsKey);
-    const argumentOptions: OptionConfig = pick(optionMeta?.config || {}, argumentsKey);
+    let flagOptions: OptionConfig = omit(optionMeta?.config || {}, argumentsKey);
+    let argumentOptions: OptionConfig = pick(optionMeta?.config || {}, argumentsKey);
     if (inheritCommand && !optionMeta?.override) {
-      Object.assign(flagOptions, inheritCommand.flagOptions);
-      Object.assign(argumentOptions, inheritCommand.argumentOptions);
+      flagOptions = Object.assign({}, inheritCommand.flagOptions, flagOptions);
+      argumentOptions = Object.assign({}, inheritCommand.argumentOptions, argumentOptions);
     }
 
     const parsedCommand = new ParsedCommand(clz, {

--- a/src/core/program.ts
+++ b/src/core/program.ts
@@ -49,7 +49,7 @@ export class Program {
 
   /** package version */
   get version() {
-    return this.binInfo?.version || '1.0.0';
+    return this.binInfo?.version || '';
   }
 
   /** bin base dir */

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -21,9 +21,9 @@ export class Utils {
   /** executing other command in same pipeline */
   async forward<T extends Record<string, any> = Record<string, any>>(clz: typeof Command | ParsedCommand, args?: T) {
     const cmd = clz instanceof ParsedCommand ? clz : this.commands.getCommand(clz);
-    assert(cmd, format('Can not forward to command %s', cmd.clz.name));
+    assert(cmd, format('Can not forward to command %s', cmd?.clz.name));
     const instance = this.ctx.container.get(cmd.clz);
-    if (args) instance[cmd.optionsKey] = args;
+    if (args && cmd.optionsKey) instance[cmd.optionsKey] = args;
     return this.trigger.executeCommand(this.ctx, cmd);
   }
 

--- a/src/plugins/plugin-help/help.ts
+++ b/src/plugins/plugin-help/help.ts
@@ -27,8 +27,8 @@ export class HelpCommand extends Command {
     const helpCommand = ctx.commands.get(command) || ctx.rootCommand;
 
     // display help informations
-    const displayTexts = [];
-    const commandLineUsageList = [];
+    const displayTexts: string[] = [];
+    const commandLineUsageList: any[] = [];
     const optionKeys = helpCommand.options ? Object.keys(helpCommand.options) : [];
 
     // usage info in first line

--- a/src/plugins/plugin-help/help.ts
+++ b/src/plugins/plugin-help/help.ts
@@ -1,7 +1,7 @@
-import { DefineCommand, Command, DefineOption, Inject, CommandContext, Program } from '../../';
+import { Option, DefineCommand, Command, DefineOption, Inject, CommandContext, Program } from '../../';
 import commandLineUsage from 'command-line-usage';
 
-interface Option {
+interface HelpOption extends Option {
   command: string;
 }
 
@@ -18,7 +18,7 @@ export class HelpCommand extends Command {
   program: Program;
 
   @DefineOption()
-  option: Option;
+  option: HelpOption;
 
   async run() {
     const ctx = this.ctx;

--- a/src/plugins/plugin-version/index.ts
+++ b/src/plugins/plugin-version/index.ts
@@ -1,7 +1,5 @@
-import { Inject, ArtusInjectEnum, ApplicationLifecycle, LifecycleHook, LifecycleHookUnit } from '@artus/core';
-import { Program, CommandContext, CommonBinConfig } from '../../';
-import fs from 'fs/promises';
-import path from 'path';
+import { Inject, ApplicationLifecycle, LifecycleHook, LifecycleHookUnit } from '@artus/core';
+import { Program, CommandContext } from '../../';
 
 @LifecycleHookUnit()
 export default class VersionLifecycle implements ApplicationLifecycle {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,14 @@ export interface CommandConfig extends Record<string, any> {
   parent?: typeof Command;
 }
 
+/** Base Option Interface */
+export interface Option {
+  /** Non-option arguments */
+  _: Array<string | number>;
+  /** Arguments after the end-of-options flag `--` */
+  '--'?: Array<string | number>;
+}
+
 export interface MiddlewareConfig {
   mergeType?: 'before' | 'after',
   middleware: MiddlewareInput;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,24 @@
 import { Command } from './core/command';
+import { Middleware, Middlewares } from '@artus/pipeline';
 
-export interface CommandProps extends Record<string, any> {
+export interface CommandConfig extends Record<string, any> {
   command?: string;
   description?: string;
   alias?: string | string[];
   override?: boolean;
   parent?: typeof Command;
+}
+
+export interface MiddlewareConfig {
+  mergeType?: 'before' | 'after',
+  middleware: MiddlewareInput;
+}
+
+export type MiddlewareInput = Middleware | Middlewares;
+
+export interface MiddlewareMeta {
+  override?: boolean;
+  configList: MiddlewareConfig[];
 }
 
 export type BasicType = 'string' | 'number' | 'boolean';
@@ -17,13 +30,18 @@ export interface OptionProps extends Record<string, any> {
   description?: string;
 }
 
+export type OptionConfig<T extends string = string> = Record<T, OptionProps>;
+
 export interface OptionMeta<T extends string = string> {
   key: string;
-  meta: Record<T, OptionProps>;
+  config: OptionConfig<T>;
+  override?: boolean;
 }
 
-export interface CommandMeta extends CommandProps {
+export interface CommandMeta {
   // nothing
+  config: CommandConfig;
+  override?: boolean;
 }
 
 export interface ApplicationOptions {

--- a/test/core/decorators.test.ts
+++ b/test/core/decorators.test.ts
@@ -104,6 +104,6 @@ describe('test/core/decorators.test.ts', () => {
     assert.throws(() => {
       Middleware(async () => {}, { override: true })(NewMyCommand);
       Middleware(async () => {}, { override: false })(NewMyCommand);
-    }, /Cannot config override in multiple @Middleware/);
+    }, /Can\'t use override in multiple @Middleware/);
   });
 });

--- a/test/core/decorators.test.ts
+++ b/test/core/decorators.test.ts
@@ -1,7 +1,8 @@
 import { ArtusApplication } from '@artus/core';
 import { createApp } from '../test-utils';
-import { DefineCommand, DefineOption, Middleware } from '@artus-cli/artus-cli';
+import { CommandMeta, DefineCommand, DefineOption, Middleware, MiddlewareConfig, MiddlewareMeta, OptionMeta } from '@artus-cli/artus-cli';
 import { MetadataEnum } from '../../src/constant';
+import { ParsedCommandTree } from '../../src/core/parsed_commands';
 import assert from 'node:assert';
 
 describe('test/core/decorators.test.ts', () => {
@@ -16,13 +17,15 @@ describe('test/core/decorators.test.ts', () => {
     options: any;
 
     @Middleware(async () => {})
+    @Middleware(async () => {})
+    @Middleware(async () => {})
     async run() {
       // nothing
     }
   }
 
   @DefineCommand()
-  @Middleware(async () => {})
+  @Middleware([ async () => {}, async () => {} ])
   class NewMyCommand extends MyCommand {
     @DefineOption()
     argv: any;
@@ -49,68 +52,58 @@ describe('test/core/decorators.test.ts', () => {
   after(() => app.close());
 
   it('DefineCommand', async () => {
-    const metadata = Reflect.getOwnMetadata(MetadataEnum.COMMAND, MyCommand);
-    assert(metadata.command === 'dev');
+    const metadata: CommandMeta = Reflect.getOwnMetadata(MetadataEnum.COMMAND, MyCommand);
+    assert(metadata.config.command === 'dev');
 
-    const metadata2 = Reflect.getOwnMetadata(MetadataEnum.COMMAND, NewMyCommand);
-    assert(metadata2.command === 'dev');
-    assert(metadata2.description);
+    const metadata2: CommandMeta = Reflect.getOwnMetadata(MetadataEnum.COMMAND, NewMyCommand);
+    assert(!metadata2.config.command);
+    assert(!metadata2.config.description);
 
     // override
-    const metadata3 = Reflect.getOwnMetadata(MetadataEnum.COMMAND, OverrideMyCommand);
-    assert(metadata3.command === 'aa');
-    assert(!metadata3.description);
+    const metadata3: CommandMeta = Reflect.getOwnMetadata(MetadataEnum.COMMAND, OverrideMyCommand);
+    assert(metadata3.config.command === 'aa');
+    assert(metadata3.override);
   });
 
   it('DefineOption', async () => {
-    const metadata = Reflect.getOwnMetadata(MetadataEnum.OPTION, MyCommand);
+    const metadata: OptionMeta = Reflect.getOwnMetadata(MetadataEnum.OPTION, MyCommand);
     assert(metadata.key === 'options');
-    assert(metadata.meta.port);
+    assert(metadata.config.port);
     assert('options' in MyCommand.prototype);
 
     // extend
-    const metadata2 = Reflect.getOwnMetadata(MetadataEnum.OPTION, NewMyCommand);
+    const metadata2: OptionMeta = Reflect.getOwnMetadata(MetadataEnum.OPTION, NewMyCommand);
     assert(metadata2.key === 'argv');
-    assert(metadata2.meta.port);
     assert('argv' in NewMyCommand.prototype);
 
     // override
-    const metadata3 = Reflect.getOwnMetadata(MetadataEnum.OPTION, OverrideMyCommand);
-    assert(!metadata3.meta.port);
+    const metadata3: OptionMeta = Reflect.getOwnMetadata(MetadataEnum.OPTION, OverrideMyCommand);
+    assert(metadata3.override);
   });
 
   it('Middlware', async () => {
-    const commandMiddleware = Reflect.getOwnMetadata(MetadataEnum.MIDDLEWARE, MyCommand);
-    assert(commandMiddleware.length === 1);
+    const commandMiddleware: MiddlewareMeta = Reflect.getOwnMetadata(MetadataEnum.MIDDLEWARE, MyCommand);
+    assert(commandMiddleware.configList.length === 1);
+    assert(typeof commandMiddleware.configList[0].middleware === 'function');
 
-    const executionMiddleware = Reflect.getOwnMetadata(MetadataEnum.RUN_MIDDLEWARE, MyCommand);
-    assert(executionMiddleware.length === 1);
+    const executionMiddleware: MiddlewareMeta = Reflect.getOwnMetadata(MetadataEnum.RUN_MIDDLEWARE, MyCommand);
+    assert(executionMiddleware.configList.length === 3);
+    assert(executionMiddleware.configList.every(m => typeof m.middleware === 'function'));
 
-    // extend command middlewares
-    const commandMiddleware2 = Reflect.getOwnMetadata(MetadataEnum.MIDDLEWARE, NewMyCommand);
-    assert(commandMiddleware2.length === 2);
-
-    // run method should not extend
-    const executionMiddleware2 = Reflect.getOwnMetadata(MetadataEnum.RUN_MIDDLEWARE, NewMyCommand);
-    assert(!executionMiddleware2);
+    const commandMiddleware2: MiddlewareMeta = Reflect.getOwnMetadata(MetadataEnum.MIDDLEWARE, NewMyCommand);
+    assert(commandMiddleware2.configList.length === 1);
+    assert(Array.isArray(commandMiddleware2.configList[0].middleware));
+    assert(commandMiddleware2.configList[0].middleware.length === 2);
 
     // should throw with other method
     assert.throws(() => {
       Middleware(async () => {})(new NewMyCommand(), 'other' as any);
     }, /Middleware can only be used in Command Class or run method/);
 
-    // should works with merge type
-    const beforeMiddlewareFn = async () => {};
-    Middleware(beforeMiddlewareFn, { mergeType: 'before' })(NewMyCommand);
-    const commandMiddleware3 = Reflect.getOwnMetadata(MetadataEnum.MIDDLEWARE, NewMyCommand);
-    assert(commandMiddleware3.length === 3);
-    assert(commandMiddleware3[0] === beforeMiddlewareFn);
-
-    // should override
-    const overrideMiddlewareFn = async () => {};
-    Middleware(overrideMiddlewareFn, { override: true })(NewMyCommand);
-    const commandMiddleware4 = Reflect.getOwnMetadata(MetadataEnum.MIDDLEWARE, NewMyCommand);
-    assert(commandMiddleware4.length === 1);
-    assert(commandMiddleware4[0] === overrideMiddlewareFn);
+    // should throw with multiple override
+    assert.throws(() => {
+      Middleware(async () => {}, { override: true })(NewMyCommand);
+      Middleware(async () => {}, { override: false })(NewMyCommand);
+    }, /Cannot config override in multiple @Middleware/);
   });
 });

--- a/test/core/parsed_commands.test.ts
+++ b/test/core/parsed_commands.test.ts
@@ -127,6 +127,7 @@ describe('test/core/parsed_commands.test.ts', () => {
     class MyCommand {
       @DefineOption({
         port: {},
+        inspectPort: { default: 8080 },
         baseDir: {},
       })
       options: any;
@@ -143,7 +144,9 @@ describe('test/core/parsed_commands.test.ts', () => {
     @Middleware([ async () => {}, afterFn ])
     @Middleware([ beforeFn ], { mergeType: 'before' })
     class NewMyCommand extends MyCommand {
-      @DefineOption()
+      @DefineOption({
+        inspectPort: { default: 6666 },
+      })
       argv: any;
     
       async run() {
@@ -168,6 +171,7 @@ describe('test/core/parsed_commands.test.ts', () => {
     assert(parsedMyCommand.clz === MyCommand);
     assert(parsedMyCommand.cmd === 'dev');
     assert(parsedMyCommand.flagOptions.port);
+    assert(parsedMyCommand.flagOptions.inspectPort.default === 8080);
     assert(!parsedMyCommand.flagOptions.baseDir);
     assert(parsedMyCommand.argumentOptions.baseDir);
     assert(parsedMyCommand.description === '666');
@@ -179,6 +183,7 @@ describe('test/core/parsed_commands.test.ts', () => {
     assert(parsedNewMyCommand.uid === 'my-bin dev');
     assert(parsedNewMyCommand.description === '666');
     assert(parsedNewMyCommand.flagOptions.port);
+    assert(parsedNewMyCommand.flagOptions.inspectPort.default === 6666);
     assert(parsedNewMyCommand.argumentOptions.baseDir);
     assert(parsedNewMyCommand.commandMiddlewares.length === 4);
     assert(parsedNewMyCommand.commandMiddlewares[0] === beforeFn);

--- a/test/core/program.test.ts
+++ b/test/core/program.test.ts
@@ -1,5 +1,5 @@
 import { ArtusApplication } from '@artus/core';
-import { DevCommand, MainCommand } from 'egg-bin';
+import { DebugCommand, DevCommand, MainCommand } from 'egg-bin';
 import { Program } from '@artus-cli/artus-cli';
 import { CommandTrigger } from '../../src/core/trigger';
 import { createApp } from '../test-utils';
@@ -36,6 +36,16 @@ describe('test/core/program.test.ts', () => {
       await next();
     });
 
+    program.useInCommand(DevCommand, async (_ctx, next) => {
+      callStack.push('dev');
+      await next();
+    });
+
+    program.useInCommand(DebugCommand, async (_ctx, next) => {
+      callStack.push('debug');
+      await next();
+    });
+
     program.useInExecution(DevCommand, async (_ctx, next) => {
       callStack.push('execution');
       await next();
@@ -43,11 +53,11 @@ describe('test/core/program.test.ts', () => {
 
     const trigger = app.container.get(CommandTrigger);
     await trigger.executePipeline({ argv: [ 'dev' ] });
-    assert.deepEqual(callStack, [ 'pipeline', 'command', 'execution' ]);
+    assert.deepEqual(callStack, [ 'pipeline', 'command', 'dev', 'execution' ]);
 
     callStack.length = 0;
     await trigger.executePipeline({ argv: [ 'debug' ] });
-    assert.deepEqual(callStack, [ 'pipeline', 'command' ]);
+    assert.deepEqual(callStack, [ 'pipeline', 'debug' ]);
 
     callStack.length = 0;
     await trigger.executePipeline({ argv: [] });

--- a/test/fixtures/argument-bin/special.ts
+++ b/test/fixtures/argument-bin/special.ts
@@ -1,0 +1,37 @@
+import { DefineCommand, DefineOption, Command } from '@artus-cli/artus-cli';
+
+interface Option {
+  baseDir: string;
+}
+
+@DefineCommand({
+  command: 'dev [baseDir]',
+})
+export class ArgumentDevComand extends Command {
+  @DefineOption<Option>({
+    baseDir: { type: 'string' },
+  })
+  opt: Option;
+
+  async run() {
+    console.info('baseDir', this.opt.baseDir);
+  }
+}
+
+interface DebugOption {
+  port: number;
+}
+
+@DefineCommand({
+  command: 'debug',
+})
+export class ArgumentDebugComand extends ArgumentDevComand {
+  @DefineOption<DebugOption>({
+    port: { type: 'number' },
+  })
+  argv: DebugOption;
+
+  async run() {
+    console.info('baseDir', this.argv.port);
+  }
+}

--- a/test/fixtures/egg-bin/cmd/dev.ts
+++ b/test/fixtures/egg-bin/cmd/dev.ts
@@ -1,6 +1,6 @@
-import { DefineCommand, DefineOption, Command, Middleware } from '@artus-cli/artus-cli';
+import { DefineCommand, DefineOption, Command, Middleware, Option } from '@artus-cli/artus-cli';
 
-export interface DevOption {
+export interface DevOption extends Option {
   port?: number;
   inspect?: string;
   nodeFlags?: string;

--- a/test/fixtures/egg-bin/cmd/test.ts
+++ b/test/fixtures/egg-bin/cmd/test.ts
@@ -1,6 +1,6 @@
-import { DefineCommand, DefineOption, Command, Middleware } from '@artus-cli/artus-cli';
+import { DefineCommand, DefineOption, Command, Middleware, Option } from '@artus-cli/artus-cli';
 
-export interface TestOption {
+export interface TestOption extends Option {
   baseDir: string;
   file: string[]
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -160,5 +160,10 @@ describe('test/index.test.ts', () => {
       .expect('stdout', /--inspect        Inspect/)
       .notExpect('stdout', /--port/)
       .end();
+
+    await fork('argument-bin', [ 'debug', '-h' ])
+      .debug()
+      .notExpect('stdout', /--base-dir/)
+      .end();
   });
 });

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -17,7 +17,7 @@ export function fork(target: string, args: string[] = [], options: ForkOptions =
 }
 
 export async function createApp(fixtureName: string, opt?: ApplicationOptions) {
-  return await start({ ...opt, baseDir: path.dirname(require.resolve(`${fixtureName}/package.json`)) });
+  return (await start({ ...opt, baseDir: path.dirname(require.resolve(`${fixtureName}/package.json`)) }))!;
 }
 
 export async function createCtx(app: ArtusApplication, argv: string[]) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@artus/tsconfig",
   "compilerOptions": {
     "baseUrl": ".",
+    "strictNullChecks": true,
     "noUnusedParameters": false,
     "noUnusedLocals":false,
     "resolveJsonModule": true,


### PR DESCRIPTION
- 将 `strictNullCheck` 配置加上，修复各种类型错误。
- 增加一个基础 Option 类型，提供 `_` 和 `--` 的类型提示。
- 将对 metadata 的处理（ 合并、继承 ），从原来直接在装饰器中处理，改成在 parsed command 中进行，这样更合理，避免不同 pipeline 之间的数据污染，同时方便区分 `argumentOptions` 和 `flagsOptions`