### PR TITLE
feat: print location in conflict

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -8,10 +8,11 @@ export interface CommandConfig extends Record<string, any> {
   description?: string;
   /** command alias */
   alias?: string | string[];
-  /** whether override exists command */
-  override?: boolean;
   /** parent command */
   parent?: typeof Command;
+
+  /** whether override exists command */
+  ignoreConflict?: boolean;
 }
 
 /** Base Option Interface */
@@ -75,6 +76,7 @@ export interface CommandMeta {
   // nothing
   config: CommandConfig;
   override?: boolean;
+  location?: string;
 }
 
 export interface ArtusCliOptions extends Partial<ArtusCliConfig> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,24 +53,29 @@ export async function readPkg(baseDir: string) {
   };
 }
 
-export function getCalleeFile(stackIndex: number): string | undefined {
+export function getCalleeList(traceLimit: number) {
   const limit = Error.stackTraceLimit;
   const prep = Error.prepareStackTrace;
 
   Error.prepareStackTrace = prepareObjectStackTrace;
-  Error.stackTraceLimit = stackIndex + 1;
+  Error.stackTraceLimit = traceLimit;
 
   const obj: any = {};
   Error.captureStackTrace(obj);
-  const fileName = obj.stack[stackIndex]?.getFileName();
+  const stack: any[] = obj.stack;
 
   Error.prepareStackTrace = prep;
   Error.stackTraceLimit = limit;
-  return fileName;
+  return stack.map(s => ({
+    methodName: s.getMethodName(),
+    fileName: s.getFileName(),
+  }));
 }
 
 export function getCalleeDir(stackIndex: number): string | undefined {
-  const calleeFile = getCalleeFile(stackIndex + 1); // one more stack
+  stackIndex++; // one more stack
+  const calleeList = getCalleeList(stackIndex + 1);
+  const calleeFile = calleeList[stackIndex]?.fileName;
   return calleeFile ? path.dirname(calleeFile) : undefined;
 }
 

--- a/test/core/decorators.test.ts
+++ b/test/core/decorators.test.ts
@@ -53,6 +53,7 @@ describe('test/core/decorators.test.ts', () => {
   it('DefineCommand', async () => {
     const metadata: CommandMeta = Reflect.getOwnMetadata(MetadataEnum.COMMAND, MyCommand);
     assert(metadata.config.command === 'dev');
+    assert(metadata.location === __filename);
 
     const metadata2: CommandMeta = Reflect.getOwnMetadata(MetadataEnum.COMMAND, NewMyCommand);
     assert(!metadata2.config.command);

--- a/test/core/parsed_commands.test.ts
+++ b/test/core/parsed_commands.test.ts
@@ -90,6 +90,15 @@ describe('test/core/parsed_commands.test.ts', () => {
     });
   });
 
+  it('should get right location with extending command', async () => {
+    app = await createApp('chair-bin', { strict: false });
+    parsedCommands = app.container.get(ParsedCommands);
+
+    const devCommand = parsedCommands.commands.get('chair-bin dev');
+    assert(devCommand?.location === path.resolve(__dirname, '../fixtures/chair-bin/cmd/dev.ts'));
+    assert(devCommand?.inherit?.location === path.resolve(__dirname, '../fixtures/egg-bin/cmd/dev.ts'));
+  });
+
   it('match command with strict=false', async () => {
     app = await createApp('chair-bin', { strict: false });
     parsedCommands = app.container.get(ParsedCommands);

--- a/test/fixtures/override/index.ts
+++ b/test/fixtures/override/index.ts
@@ -3,7 +3,7 @@ import { DefineCommand, Command } from '@artus-cli/artus-cli';
 @DefineCommand({
   command: 'dev',
   description: 'Run simple dev',
-  override: true,
+  ignoreConflict: true,
 })
 export class ChairDevCommand extends Command {
   async run() {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,5 @@
 import { ArtusApplication } from '@artus/core';
-import { checkCommandCompatible, isInheritFrom, isNil, readPkg, getCalleeDir, getCalleeFile } from '../src/utils';
+import { checkCommandCompatible, isInheritFrom, isNil, readPkg, getCalleeList, getCalleeDir } from '../src/utils';
 import { DevCommand, DebugCommand, MainCommand } from 'egg-bin';
 import { ParsedCommands, Command } from '@artus-cli/artus-cli';
 import path from 'node:path';
@@ -40,10 +40,10 @@ describe('test/utils.test.ts', () => {
     assert(await readPkg(path.resolve(__dirname, './fixtures/egg-bin')));
   });
 
-  it('getCalleeFile/getCalleeDir', async () => {
-    assert(getCalleeFile(1) === __filename);
+  it('getCalleeList/getCalleeDir', async () => {
+    assert(getCalleeList(3).length === 3);
+    assert(getCalleeList(3)[0].fileName);
     assert(getCalleeDir(1) === __dirname);
-    assert(getCalleeFile(2)?.includes('mocha'));
     assert(getCalleeDir(2)?.includes('mocha'));
   });
 });


### PR DESCRIPTION
- 当冲突时打印 command 所在文件路径
- 把忽略冲突的参数，从原来 override 改成 ignoreConflict ，避免与元信息 override 参数混淆