### PR TITLE
refactor: rename override

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -10,9 +10,6 @@ export interface CommandConfig extends Record<string, any> {
   alias?: string | string[];
   /** parent command */
   parent?: typeof Command;
-
-  /** whether override exists command */
-  ignoreConflict?: boolean;
 }
 
 /** Base Option Interface */
@@ -30,8 +27,8 @@ export interface MiddlewareConfig {
 
 export type MiddlewareInput = Middleware | Middlewares;
 
-export interface MiddlewareMeta {
-  override?: boolean;
+export interface MiddlewareMeta extends BaseMeta {
+  /** middleware config list */
   configList: MiddlewareConfig[];
 }
 
@@ -66,17 +63,25 @@ export interface OptionProps<T extends BasicType = BasicType, G = any> extends R
 
 export type OptionConfig<T extends string = string> = Record<T, OptionProps>;
 
-export interface OptionMeta<T extends string = string> {
-  key: string;
-  config: OptionConfig<T>;
-  override?: boolean;
+export interface BaseMeta {
+  /** whether inherit meta data from prototype, default to true */
+  inheritMetadata?: boolean;
 }
 
-export interface CommandMeta {
-  // nothing
+export interface OptionMeta<T extends string = string> extends BaseMeta {
+  /** option prop key */
+  key: string;
+  /** option config */
+  config: OptionConfig<T>;
+}
+
+export interface CommandMeta extends BaseMeta {
+  /** command config */
   config: CommandConfig;
-  override?: boolean;
+  /** Command Class location */
   location?: string;
+  /** whether override exists conflict command */
+  overrideCommand?: boolean;
 }
 
 export interface ArtusCliOptions extends Partial<ArtusCliConfig> {

--- a/test/core/decorators.test.ts
+++ b/test/core/decorators.test.ts
@@ -34,9 +34,9 @@ describe('test/core/decorators.test.ts', () => {
     }
   }
 
-  @DefineCommand({ command: 'aa' }, { override: true })
+  @DefineCommand({ command: 'aa' }, { inheritMetadata: false })
   class OverrideMyCommand extends MyCommand {
-    @DefineOption({}, { override: true })
+    @DefineOption({}, { inheritMetadata: false })
     argv: any;
 
     async run() {
@@ -59,10 +59,10 @@ describe('test/core/decorators.test.ts', () => {
     assert(!metadata2.config.command);
     assert(!metadata2.config.description);
 
-    // override
+    // inheritMetadata
     const metadata3: CommandMeta = Reflect.getOwnMetadata(MetadataEnum.COMMAND, OverrideMyCommand);
     assert(metadata3.config.command === 'aa');
-    assert(metadata3.override);
+    assert(metadata3.inheritMetadata === false);
   });
 
   it('DefineOption', async () => {
@@ -76,9 +76,9 @@ describe('test/core/decorators.test.ts', () => {
     assert(metadata2.key === 'argv');
     assert('argv' in NewMyCommand.prototype);
 
-    // override
+    // inheritMetadata
     const metadata3: OptionMeta = Reflect.getOwnMetadata(MetadataEnum.OPTION, OverrideMyCommand);
-    assert(metadata3.override);
+    assert(metadata3.inheritMetadata === false);
   });
 
   it('Middlware', async () => {
@@ -102,8 +102,8 @@ describe('test/core/decorators.test.ts', () => {
 
     // should throw with multiple override
     assert.throws(() => {
-      Middleware(async () => 1, { override: true })(NewMyCommand);
-      Middleware(async () => 1, { override: false })(NewMyCommand);
-    }, /Can\'t use override in multiple @Middleware/);
+      Middleware(async () => 1, { inheritMetadata: true })(NewMyCommand);
+      Middleware(async () => 1, { inheritMetadata: false })(NewMyCommand);
+    }, /Can\'t use inheritMetadata in multiple @Middleware/);
   });
 });

--- a/test/core/parsed_commands.test.ts
+++ b/test/core/parsed_commands.test.ts
@@ -208,10 +208,10 @@ describe('test/core/parsed_commands.test.ts', () => {
       return DefineCommand(...args);
     }
 
-    @NewDefineCommand({ command: 'aa' }, { override: true })
-    @Middleware([ async () => 1, async () => 1 ], { override: true })
+    @NewDefineCommand({ command: 'aa' }, { inheritMetadata: false })
+    @Middleware([ async () => 1, async () => 1 ], { inheritMetadata: false })
     class OverrideMyCommand extends MyCommand {
-      @DefineOption({}, { override: true })
+      @DefineOption({}, { inheritMetadata: false })
       argv: any;
     
       async run() {
@@ -226,7 +226,7 @@ describe('test/core/parsed_commands.test.ts', () => {
       }
     }
 
-    @DefineCommand({ command: 'aa', ignoreConflict: true })
+    @DefineCommand({ command: 'aa' }, { overrideCommand: true })
     class NotConflicMyCommand extends MyCommand {
       async run() {
         // nothing

--- a/test/fixtures/egg-bin/cmd/dev.ts
+++ b/test/fixtures/egg-bin/cmd/dev.ts
@@ -2,7 +2,7 @@ import { DefineCommand, DefineOption, Command, Middleware, Option } from '@artus
 
 export interface DevOption extends Option {
   port?: number;
-  inspect?: string;
+  inspect?: boolean;
   nodeFlags?: string;
   baseDir?: string;
 }

--- a/test/fixtures/override/index.ts
+++ b/test/fixtures/override/index.ts
@@ -3,8 +3,7 @@ import { DefineCommand, Command } from '@artus-cli/artus-cli';
 @DefineCommand({
   command: 'dev',
   description: 'Run simple dev',
-  ignoreConflict: true,
-})
+}, { overrideCommand: true })
 export class ChairDevCommand extends Command {
   async run() {
     console.info('extractly override');


### PR DESCRIPTION
- 将继承元数据的配置，从 `override` 改成 `inheritMetadata` ，语义更清晰。（ 默认为 true ，不需要继承设置为 false ）
- 将指令覆盖的配置挪到第二个参数中，改成 `overrideCommand` ，语义为覆盖指令