### PR TITLE
feat: update define option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,32 +20,23 @@
 ## How it looks
 
 ```ts
-import { DefineCommand, DefineOption, Command } from '@artus-cli/artus-cli';
-
-export interface DevOptions {
-  port?: number;
-  baseDir?: string;
-}
+import { DefineCommand, Option, Command } from '@artus-cli/artus-cli';
 
 @DefineCommand({
-  command: 'dev [baseDir]',
+  command: 'dev',
   description: 'Run the development server',
   alias: [ 'd' ],
 })
 export class DevCommand extends Command {
-  @DefineOption<DevOptions>({
-    port: {
-      type: 'number',
-      alias: 'p',
-      default: 3000,
-      description: 'server port',
-    },
+  @Option({
+    alias: 'p',
+    default: 3000,
+    description: 'server port',
   })
-  args: DevOptions;
+  port: number;
 
   async run() {
-    console.info('port: %s', this.args.port);
-    console.info('baseDir: %s', this.args.baseDir);
+    console.info('port: %s', this.port);
   }
 }
 ```

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -8,3 +8,4 @@ export enum MetadataEnum {
 export const CONTEXT_SYMBOL = Symbol('Command#Context');
 export const EXCUTION_SYMBOL = Symbol('Command#Excution');
 export const BIN_OPTION_SYMBOL = Symbol('BinInfo#Option');
+export const COMMAND_OPTION_SYMBOL = Symbol('Command#Option');

--- a/src/core/command.ts
+++ b/src/core/command.ts
@@ -1,6 +1,17 @@
 import { Injectable } from '@artus/core';
+import { COMMAND_OPTION_SYMBOL } from '../constant';
 
 export abstract class Command {
+  /** Non-option arguments */
+  get _() {
+    return this[COMMAND_OPTION_SYMBOL]._;
+  }
+
+  /** Arguments after the end-of-options flag `--` */
+  get '--'() {
+    return this[COMMAND_OPTION_SYMBOL]['--'];
+  }
+
   abstract run(...args: any[]): Promise<any>;
 }
 

--- a/src/core/decorators.ts
+++ b/src/core/decorators.ts
@@ -57,13 +57,13 @@ export function Options<T extends object = object>(
 /** TODO: delete later */
 export const DefineOption = Options;
 
-export function Option(descOrOpt: string | OptionProps = {}) {
+export function Option(descOrOpt?: string | OptionProps) {
   return <G extends Command>(target: G, key: string) => {
     const ctor = target.constructor as typeof Command;
     const result = initOptionMeta(ctor);
     const config: OptionProps = typeof descOrOpt === 'string'
       ? { description: descOrOpt }
-      : descOrOpt;
+      : (descOrOpt || {});
 
     const designType = Reflect.getOwnMetadata('design:type', target, key);
     if (designType === String) {
@@ -143,7 +143,6 @@ function initOptionMeta(ctor: typeof Command): OptionMeta {
     });
 
     const optionMeta = {
-      key: COMMAND_OPTION_SYMBOL,
       config: {},
     } satisfies OptionMeta;
 

--- a/src/core/decorators.ts
+++ b/src/core/decorators.ts
@@ -1,11 +1,11 @@
 import { addTag, Injectable, ScopeEnum, Inject } from '@artus/core';
-import { MetadataEnum, CONTEXT_SYMBOL, EXCUTION_SYMBOL } from '../constant';
+import { MetadataEnum, CONTEXT_SYMBOL, EXCUTION_SYMBOL, COMMAND_OPTION_SYMBOL } from '../constant';
 import { ParsedCommands } from '../core/parsed_commands';
 import { CommandContext, CommandOutput } from './context';
 import compose from 'koa-compose';
 import { Command } from './command';
 import { checkCommandCompatible, getCalleeList } from '../utils';
-import { BaseMeta, MiddlewareMeta, MiddlewareInput, MiddlewareConfig, CommandConfig, OptionProps, OptionMeta, OptionConfig, ConvertTypeToBasicType, CommandMeta } from '../types';
+import { BaseMeta, MiddlewareMeta, MiddlewareInput, MiddlewareConfig, CommandConfig, OptionProps, OptionMeta, ConvertTypeToBasicType, CommandMeta } from '../types';
 
 export interface CommonDecoratorOption extends Pick<BaseMeta, 'inheritMetadata'> {}
 export interface MiddlewareDecoratorOption extends CommonDecoratorOption, Pick<MiddlewareConfig, 'mergeType'> {}
@@ -35,44 +35,62 @@ export function DefineCommand(
   };
 }
 
-export function DefineOption<T extends object = object>(
+export function Options<T extends object = object>(
   meta?: { [P in keyof Omit<T, '_' | '--'>]?: OptionProps<ConvertTypeToBasicType<T[P]>, T[P]>; },
-  option?: CommonDecoratorOption,
 ) {
   return <G extends Command>(target: G, key: string) => {
     const ctor = target.constructor as typeof Command;
-
-    // define option key
-    const keySymbol = Symbol(`${ctor.name}#${key}`);
-    Object.defineProperty(ctor.prototype, key, {
+    const result = initOptionMeta(ctor);
+    Object.assign(result.config, meta);
+    Object.defineProperty(target, key, {
       get() {
-        if (this[keySymbol]) return this[keySymbol];
-        const ctx: CommandContext = this[CONTEXT_SYMBOL];
-        if (!ctx) return;
-
-        const { matched, args, raw: argv } = ctx;
-        const parsedCommands = ctx.container.get(ParsedCommands);
-        const targetCommand = parsedCommands.getCommand(ctor);
-        // check target command whether is compatible with matched
-        const isSameCommandOrCompatible = matched?.clz === ctor || (matched && targetCommand && checkCommandCompatible(targetCommand, matched));
-        this[keySymbol] = isSameCommandOrCompatible ? args : parsedCommands.parseArgs(argv, targetCommand);
-        return this[keySymbol];
+        return this[COMMAND_OPTION_SYMBOL];
       },
 
-      set(val: any) {
-        // allow developer to override options
-        this[keySymbol] = val;
+      set(val) {
+        this[COMMAND_OPTION_SYMBOL] = val;
       },
     });
+  };
+}
 
-    const config = (meta || {}) as OptionConfig;
-    const optionMeta = {
-      key,
-      config,
-      inheritMetadata: option?.inheritMetadata,
-    } satisfies OptionMeta;
+/** TODO: delete later */
+export const DefineOption = Options;
 
-    Reflect.defineMetadata(MetadataEnum.OPTION, optionMeta, ctor);
+export function Option(descOrOpt: string | OptionProps = {}) {
+  return <G extends Command>(target: G, key: string) => {
+    const ctor = target.constructor as typeof Command;
+    const result = initOptionMeta(ctor);
+    const config: OptionProps = typeof descOrOpt === 'string'
+      ? { description: descOrOpt }
+      : descOrOpt;
+
+    const designType = Reflect.getOwnMetadata('design:type', target, key);
+    if (designType === String) {
+      config.type = 'string';  
+    } else if (designType === Number) {
+      config.type = 'number';
+    } else if (designType === Boolean) {
+      config.type = 'boolean';
+    } else if (designType === Array) {
+      config.array = true;
+    }
+
+    // merge with exists config
+    result.config[key] = {
+      ...result.config[key],
+      ...config,
+    };
+
+    Object.defineProperty(target, key, {
+      get() {
+        return this[COMMAND_OPTION_SYMBOL][key];
+      },
+
+      set(val) {
+        this[COMMAND_OPTION_SYMBOL][key] = val;
+      },
+    });
   };
 }
 
@@ -97,6 +115,42 @@ export function Middleware(fn: MiddlewareInput, option?: MiddlewareDecoratorOpti
     existsMeta.inheritMetadata = option?.inheritMetadata;
     Reflect.defineMetadata(metaKey, existsMeta, ctor);
   };
+}
+
+function initOptionMeta(ctor: typeof Command): OptionMeta {
+  if (!Reflect.hasOwnMetadata(MetadataEnum.OPTION, ctor)) {
+    // define option key
+    const optionCacheSymbol = Symbol(`${ctor.name}#cache`);
+    Object.defineProperty(ctor.prototype, COMMAND_OPTION_SYMBOL, {
+      get() {
+        if (this[optionCacheSymbol]) return this[optionCacheSymbol];
+        const ctx: CommandContext = this[CONTEXT_SYMBOL];
+        if (!ctx) return;
+
+        const { matched, args, raw: argv } = ctx;
+        const parsedCommands = ctx.container.get(ParsedCommands);
+        const targetCommand = parsedCommands.getCommand(ctor);
+        // check target command whether is compatible with matched
+        const isSameCommandOrCompatible = matched?.clz === ctor || (matched && targetCommand && checkCommandCompatible(targetCommand, matched));
+        this[optionCacheSymbol] = isSameCommandOrCompatible ? args : parsedCommands.parseArgs(argv, targetCommand);
+        return this[optionCacheSymbol];
+      },
+
+      set(val: any) {
+        // allow developer to override options
+        this[optionCacheSymbol] = val;
+      },
+    });
+
+    const optionMeta = {
+      key: COMMAND_OPTION_SYMBOL,
+      config: {},
+    } satisfies OptionMeta;
+
+    Reflect.defineMetadata(MetadataEnum.OPTION, optionMeta, ctor);
+  }
+
+  return Reflect.getOwnMetadata(MetadataEnum.OPTION, ctor);
 }
 
 /**

--- a/src/core/decorators.ts
+++ b/src/core/decorators.ts
@@ -35,7 +35,7 @@ export function DefineCommand(
   };
 }
 
-export function Options<T extends object = object>(
+export function Options<T extends Record<string, any> = Record<string, any>>(
   meta?: { [P in keyof Omit<T, '_' | '--'>]?: OptionProps<ConvertTypeToBasicType<T[P]>, T[P]>; },
 ) {
   return <G extends Command>(target: G, key: string) => {

--- a/src/core/parsed_commands.ts
+++ b/src/core/parsed_commands.ts
@@ -41,7 +41,6 @@ export interface ParsedCommandOption {
   commandConfig: CommandConfig;
   parsedCommandInfo: ParsedCommandStruct;
   optionConfig?: {
-    optionsKey?: string;
     flagOptions: OptionConfig;
     argumentOptions: OptionConfig;
   };
@@ -64,7 +63,6 @@ export class ParsedCommand implements ParsedCommandStruct {
   globalOptions?: OptionConfig;
   flagOptions: OptionConfig;
   argumentOptions: OptionConfig;
-  optionsKey?: string;
   /** Command class location */
   location?: string;
 
@@ -94,7 +92,6 @@ export class ParsedCommand implements ParsedCommandStruct {
     // read from option config
     this.flagOptions = optionConfig?.flagOptions || {};
     this.argumentOptions = optionConfig?.argumentOptions || {};
-    this.optionsKey = optionConfig?.optionsKey;
     this.childs = [];
     this.parent = null;
     this.inherit = null;
@@ -223,7 +220,7 @@ export class ParsedCommandTree {
       location: commandMeta.location,
       commandConfig,
       parsedCommandInfo,
-      optionConfig: { flagOptions, argumentOptions, optionsKey: optionMeta?.key },
+      optionConfig: { flagOptions, argumentOptions },
     });
 
     if (inheritCommand) parsedCommand.inherit = inheritCommand;

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -59,6 +59,11 @@ export function parseArgvToArgs(argv: string | string[], option: {
         parserOption.default = parserOption.default || {};
         parserOption.default[key] = opt.default;
       }
+
+      if (!isNil(opt.array)) {
+        parserOption.array = parserOption.array || [];
+        parserOption.array!.push(key as any);
+      }
     }
   }
 

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable, ScopeEnum } from '@artus/core';
 import { ParsedCommand, ParsedCommands } from './parsed_commands';
 import { Command } from './command';
+import { COMMAND_OPTION_SYMBOL } from '../constant';
 import { CommandContext } from './context';
 import { CommandTrigger } from './trigger';
 import assert from 'node:assert';
@@ -22,7 +23,7 @@ export class Utils {
     const cmd = clz instanceof ParsedCommand ? clz : this.commands.getCommand(clz);
     assert(cmd, format('Can not forward to command %s', cmd?.clz.name));
     const instance = this.ctx.container.get(cmd.clz);
-    if (args && cmd.optionsKey) instance[cmd.optionsKey] = args;
+    if (args) instance[COMMAND_OPTION_SYMBOL] = args;
     return this.trigger.executeCommand(this.ctx, cmd);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,12 +13,12 @@ export interface CommandConfig extends Record<string, any> {
 }
 
 /** Base Option Interface */
-export interface Option {
-  /** Non-option arguments */
-  _: Array<string | number>;
-  /** Arguments after the end-of-options flag `--` */
-  '--'?: Array<string | number>;
-}
+// export interface Option {
+//   /** Non-option arguments */
+//   _: Array<string | number>;
+//   /** Arguments after the end-of-options flag `--` */
+//   '--'?: Array<string | number>;
+// }
 
 export interface MiddlewareConfig {
   mergeType?: 'before' | 'after',
@@ -55,6 +55,7 @@ export type ConvertTypeToBasicType<T> = (
 
 export interface OptionProps<T extends BasicType = BasicType, G = any> extends Record<string, any> {
   type?: T;
+  array?: boolean;
   alias?: string | string[];
   default?: G;
   required?: boolean;
@@ -70,7 +71,7 @@ export interface BaseMeta {
 
 export interface OptionMeta<T extends string = string> extends BaseMeta {
   /** option prop key */
-  key: string;
+  key: string | symbol;
   /** option config */
   config: OptionConfig<T>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,8 +70,6 @@ export interface BaseMeta {
 }
 
 export interface OptionMeta<T extends string = string> extends BaseMeta {
-  /** option prop key */
-  key: string | symbol;
   /** option config */
   config: OptionConfig<T>;
 }

--- a/test/core/decorators.test.ts
+++ b/test/core/decorators.test.ts
@@ -1,6 +1,6 @@
 import { ArtusApplication } from '@artus/core';
 import { createApp } from '../test-utils';
-import { CommandMeta, DefineCommand, DefineOption, Middleware, MiddlewareMeta, OptionMeta } from '@artus-cli/artus-cli';
+import { CommandMeta, DefineCommand, Command, Option, Options, Middleware, MiddlewareMeta, OptionMeta } from '@artus-cli/artus-cli';
 import { MetadataEnum } from '../../src/constant';
 import assert from 'node:assert';
 
@@ -9,11 +9,12 @@ describe('test/core/decorators.test.ts', () => {
 
   @DefineCommand({ command: 'dev', description: '666' })
   @Middleware(async () => 1)
-  class MyCommand {
-    @DefineOption({
-      port: {},
-    })
-    options: any;
+  class MyCommand extends Command {
+    @Option()
+    port: number;
+
+    @Options()
+    args: any;
 
     @Middleware(async () => 1)
     @Middleware(async () => 1)
@@ -26,7 +27,7 @@ describe('test/core/decorators.test.ts', () => {
   @DefineCommand()
   @Middleware([ async () => 1, async () => 1 ])
   class NewMyCommand extends MyCommand {
-    @DefineOption()
+    @Options()
     argv: any;
 
     async run() {
@@ -36,9 +37,6 @@ describe('test/core/decorators.test.ts', () => {
 
   @DefineCommand({ command: 'aa' }, { inheritMetadata: false })
   class OverrideMyCommand extends MyCommand {
-    @DefineOption({}, { inheritMetadata: false })
-    argv: any;
-
     async run() {
       // nothing
     }
@@ -65,20 +63,15 @@ describe('test/core/decorators.test.ts', () => {
     assert(metadata3.inheritMetadata === false);
   });
 
-  it('DefineOption', async () => {
+  it('Option/Options', async () => {
     const metadata: OptionMeta = Reflect.getOwnMetadata(MetadataEnum.OPTION, MyCommand);
-    assert(metadata.key === 'options');
     assert(metadata.config.port);
-    assert('options' in MyCommand.prototype);
+    assert('args' in MyCommand.prototype);
 
     // extend
     const metadata2: OptionMeta = Reflect.getOwnMetadata(MetadataEnum.OPTION, NewMyCommand);
-    assert(metadata2.key === 'argv');
+    assert(metadata2.config);
     assert('argv' in NewMyCommand.prototype);
-
-    // inheritMetadata
-    const metadata3: OptionMeta = Reflect.getOwnMetadata(MetadataEnum.OPTION, OverrideMyCommand);
-    assert(metadata3.inheritMetadata === false);
   });
 
   it('Middlware', async () => {

--- a/test/core/parsed_commands.test.ts
+++ b/test/core/parsed_commands.test.ts
@@ -1,7 +1,7 @@
 import { ArtusApplication } from '@artus/core';
 import { DevCommand, DebugCommand, MainCommand } from 'egg-bin';
 import { ArgumentMainComand } from 'argument-bin';
-import { ErrorCode, ParsedCommandTree, DefineCommand, DefineOption, Middleware, ParsedCommands, Program, EmptyCommand } from '@artus-cli/artus-cli';
+import { ErrorCode, ParsedCommandTree, DefineCommand, Options, Middleware, ParsedCommands, Program, EmptyCommand, Command } from '@artus-cli/artus-cli';
 import { createApp } from '../test-utils';
 import assert from 'node:assert';
 import path from 'node:path';
@@ -205,8 +205,8 @@ describe('test/core/parsed_commands.test.ts', () => {
 
     @DefineCommand({ command: 'dev [baseDir]', description: '666' })
     @Middleware(async () => 1)
-    class MyCommand {
-      @DefineOption({
+    class MyCommand extends Command {
+      @Options({
         port: {},
         inspectPort: { default: 8080 },
         baseDir: {},
@@ -225,7 +225,7 @@ describe('test/core/parsed_commands.test.ts', () => {
     @Middleware([ async () => 1, afterFn ])
     @Middleware([ beforeFn ], { mergeType: 'before' })
     class NewMyCommand extends MyCommand {
-      @DefineOption({
+      @Options({
         inspectPort: { default: 6666 },
       })
       argv: any;
@@ -242,9 +242,6 @@ describe('test/core/parsed_commands.test.ts', () => {
     @NewDefineCommand({ command: 'aa' }, { inheritMetadata: false })
     @Middleware([ async () => 1, async () => 1 ], { inheritMetadata: false })
     class OverrideMyCommand extends MyCommand {
-      @DefineOption({}, { inheritMetadata: false })
-      argv: any;
-    
       async run() {
         // nothing
       }

--- a/test/fixtures/argument-bin/index.ts
+++ b/test/fixtures/argument-bin/index.ts
@@ -1,4 +1,4 @@
-import { DefineCommand, DefineOption, Command } from '@artus-cli/artus-cli';
+import { DefineCommand, Option, Command } from '@artus-cli/artus-cli';
 
 interface Option {
   port?: number;
@@ -9,21 +9,14 @@ interface Option {
   command: '$0 [port]',
 })
 export class ArgumentMainComand extends Command {
-  @DefineOption<Option>({
-    port: {
-      type: 'number',
-      default: 3000,
-    },
+  @Option({ default: 3000 })
+  port: number;
 
-    inspect: {
-      type: 'boolean',
-      description: 'Inspect',
-    },
-  })
-  args: Option;
+  @Option('Inspect')
+  inspect: boolean;
 
   async run() {
-    console.info('serv in port', this.args.port);
-    if (this.args.inspect) console.info('serv is inspecting...');
+    console.info('serv in port', this.port);
+    if (this.inspect) console.info('serv is inspecting...');
   }
 }

--- a/test/fixtures/argument-bin/special.ts
+++ b/test/fixtures/argument-bin/special.ts
@@ -1,4 +1,4 @@
-import { DefineCommand, DefineOption, Command } from '@artus-cli/artus-cli';
+import { DefineCommand, Option, Command } from '@artus-cli/artus-cli';
 
 interface Option {
   baseDir: string;
@@ -8,7 +8,7 @@ interface Option {
   command: 'dev [baseDir]',
 })
 export class ArgumentDevComand extends Command {
-  @DefineOption<Option>({
+  @Option<Option>({
     baseDir: { type: 'string' },
   })
   opt: Option;
@@ -26,7 +26,7 @@ interface DebugOption {
   command: 'debug',
 })
 export class ArgumentDebugComand extends ArgumentDevComand {
-  @DefineOption<DebugOption>({
+  @Option<DebugOption>({
     port: { type: 'number' },
   })
   argv: DebugOption;

--- a/test/fixtures/chair-bin/cmd/dev.ts
+++ b/test/fixtures/chair-bin/cmd/dev.ts
@@ -1,10 +1,5 @@
-import { DefineCommand, DefineOption, Middleware } from '@artus-cli/artus-cli';
-import { DevCommand as BaseDevCommand, DevOption as BaseDevOption } from 'egg-bin';
-
-export interface DevOption extends BaseDevOption {
-  other?: string;
-  daemon?: boolean;
-}
+import { DefineCommand, Option, Middleware } from '@artus-cli/artus-cli';
+import { DevCommand as BaseDevCommand } from 'egg-bin';
 
 @DefineCommand({
   description: 'Run the development server with chair-bin',
@@ -15,23 +10,16 @@ export interface DevOption extends BaseDevOption {
   console.info('chair-bin dev command postrun');
 })
 export class ChairDevCommand extends BaseDevCommand {
-  @DefineOption<DevOption>({
-    other: {
-      type: 'string',
-      alias: 'o',
-    },
+  @Option({ alias: 'o' })
+  other: string;
 
-    daemon: {
-      type: 'boolean',
-      default: false,
-    },
-  })
-  args: DevOption;
+  @Option()
+  daemon: boolean;
 
   async run() {
     const r = await super.run();
-    console.info('other', this.args.other);
-    console.info('daemon', this.args.daemon);
+    console.info('other', this.other);
+    console.info('daemon', this.daemon);
     return r;
   }
 }

--- a/test/fixtures/chair-bin/cmd/module/debug.ts
+++ b/test/fixtures/chair-bin/cmd/module/debug.ts
@@ -8,7 +8,7 @@ import { DebugCommand } from 'egg-bin';
 })
 export class ModuleDebugCommand extends DebugCommand {
   async run() {
-    console.info('module is debug in', this.args.baseDir);
+    console.info('module is debug in', this.baseDir);
     return {} as any;
   }
 }

--- a/test/fixtures/chair-bin/cmd/module/dev.ts
+++ b/test/fixtures/chair-bin/cmd/module/dev.ts
@@ -8,7 +8,7 @@ import { ChairDevCommand } from '../dev';
 })
 export class ModuleDevCommand extends ChairDevCommand {
   async run() {
-    console.info('module is dev in', this.args.baseDir);
+    console.info('module is dev in', this.baseDir);
     return {} as any;
   }
 }

--- a/test/fixtures/chair-bin/cmd/oneapi/client.ts
+++ b/test/fixtures/chair-bin/cmd/oneapi/client.ts
@@ -1,14 +1,14 @@
-import { DefineCommand, DefineOption } from '@artus-cli/artus-cli';
+import { DefineCommand, Option, Command } from '@artus-cli/artus-cli';
 
 @DefineCommand({
   command: 'oneapi client [appName]',
   description: 'Run the oneapi client',
 })
-export class OneapiClientCommand {
-  @DefineOption()
-  options: any;
+export class OneapiClientCommand extends Command {
+  @Option()
+  appName: string;
 
   async run() {
-    console.info('oneapi client', this.options.appName);
+    console.info('oneapi client', this.appName);
   }
 }

--- a/test/fixtures/chair-bin/cmd/oneapi/server.ts
+++ b/test/fixtures/chair-bin/cmd/oneapi/server.ts
@@ -1,14 +1,14 @@
-import { DefineCommand, DefineOption } from '@artus-cli/artus-cli';
+import { DefineCommand, Option, Command } from '@artus-cli/artus-cli';
 
 @DefineCommand({
   command: 'oneapi server [appName]',
   description: 'Run the oneapi server',
 })
-export class OneapiServerCommand {
-  @DefineOption()
-  options: any;
+export class OneapiServerCommand extends Command {
+  @Option()
+  appName: string;
 
   async run() {
-    console.info('oneapi server', this.options.appName);
+    console.info('oneapi server', this.appName);
   }
 }

--- a/test/fixtures/chair-bin/cmd/user.ts
+++ b/test/fixtures/chair-bin/cmd/user.ts
@@ -1,10 +1,6 @@
-import { Inject, DefineCommand, DefineOption, Command, CommandContext, Middleware } from '@artus-cli/artus-cli';
+import { Inject, DefineCommand, Option, Command, CommandContext, Middleware } from '@artus-cli/artus-cli';
 import { UserService } from '../service/user';
 import { AuthService } from '../service/auth';
-
-export interface UserOption {
-  authCode: string;
-}
 
 async function authMiddleware(ctx: CommandContext, next) {
   const authService = ctx.container.get(AuthService);
@@ -26,13 +22,8 @@ async function authMiddleware(ctx: CommandContext, next) {
 })
 @Middleware(authMiddleware)
 export class ChairUserCommand extends Command {
-  @DefineOption<UserOption>({
-    authCode: {
-      type: 'string',
-      alias: 'u',
-    },
-  })
-  args: UserOption;
+  @Option({ alias: 'u' })
+  authCode: string;
 
   @Inject()
   userService: UserService;

--- a/test/fixtures/deep-bin/src/cmd/main.ts
+++ b/test/fixtures/deep-bin/src/cmd/main.ts
@@ -1,27 +1,22 @@
 // index.ts
-import { DefineCommand, DefineOption, Command } from '@artus-cli/artus-cli';
-
-interface Option {
-  port: number;
-  baseDir: string;
-}
+import { DefineCommand, Option, Command } from '@artus-cli/artus-cli';
 
 @DefineCommand({
   command: '$0 [baseDir]',
   description: 'My Deep Bin',
 })
 export class MainCommand extends Command {
-  @DefineOption<Option>({
-    port: {
-      type: 'number',
-      alias: 'p',
-      default: 3000,
-      description: 'port',
-    },
+  @Option({
+    alias: 'p',
+    default: 3000,
+    description: 'port',
   })
-  option: Option;
+  port: number;
+
+  @Option()
+  baseDir: string;
 
   async run() {
-    console.info('Run with port %s in %s', this.option.port, this.option.baseDir);
+    console.info('Run with port %s in %s', this.port, this.baseDir);
   }
 }

--- a/test/fixtures/egg-bin/cmd/cov.ts
+++ b/test/fixtures/egg-bin/cmd/cov.ts
@@ -1,28 +1,19 @@
-import { DefineCommand, DefineOption, Command, Inject } from '@artus-cli/artus-cli';
-import { TestCommand, TestOption } from './test';
-
-interface CovOption extends TestOption {
-  c8?: boolean;
-}
+import { DefineCommand, Option, Command, Inject } from '@artus-cli/artus-cli';
+import { TestCommand } from './test';
 
 @DefineCommand({
   command: 'cov <baseDir> [file...]',
   description: 'Run the coverage',
 })
 export class CovCommand extends Command {
-  @DefineOption<CovOption>({
-    c8: {
-      type: 'boolean',
-      default: true,
-    },
-  })
-  args: CovOption;
+  @Option({ default: true })
+  c8: boolean;
 
   @Inject()
   testCommand: TestCommand;
 
   async run() {
-    console.info('coverage c8', this.args.c8);
+    console.info('coverage c8', this.c8);
     return this.testCommand.run();
   }
 }

--- a/test/fixtures/egg-bin/cmd/debug.ts
+++ b/test/fixtures/egg-bin/cmd/debug.ts
@@ -1,29 +1,22 @@
-import { DefineCommand, DefineOption } from '@artus-cli/artus-cli';
-import { DevCommand, DevOption } from './dev';
-
-interface DebugOption extends DevOption {
-  flags?: string;
-}
+import { DefineCommand, Option } from '@artus-cli/artus-cli';
+import { DevCommand } from './dev';
 
 @DefineCommand({
   command: 'debug [baseDir]',
   description: 'Run the development server at debug mode',
 })
 export class DebugCommand extends DevCommand {
-  @DefineOption<DebugOption>({
-    flags: {
-      type: 'number',
-      alias: 'f',
-      default: 0,
-    },
+  @Option({
+    alias: 'f',
+    default: 0,
   })
-  args: DebugOption;
+  flags: number;
 
   async run() {
-    console.info('port', this.args.port);
-    console.info('inspect', this.args.inspect);
-    console.info('flags', this.args.flags);
-    console.info('baseDir', this.args.baseDir);
+    console.info('port', this.port);
+    console.info('inspect', this.inspect);
+    console.info('flags', this.flags);
+    console.info('baseDir', this.baseDir);
     return {
       command: 'debug',
       args: this.args,

--- a/test/fixtures/egg-bin/cmd/dev.ts
+++ b/test/fixtures/egg-bin/cmd/dev.ts
@@ -1,11 +1,4 @@
-import { DefineCommand, DefineOption, Command, Middleware, Option } from '@artus-cli/artus-cli';
-
-export interface DevOption extends Option {
-  port?: number;
-  inspect?: boolean;
-  nodeFlags?: string;
-  baseDir?: string;
-}
+import { DefineCommand, Option, Options, Command, Middleware } from '@artus-cli/artus-cli';
 
 @DefineCommand({
   command: 'dev [baseDir]',
@@ -18,31 +11,33 @@ export interface DevOption extends Option {
   console.info('egg-bin dev command postrun');
 })
 export class DevCommand extends Command {
-  @DefineOption<DevOption>({
-    port: {
-      type: 'number',
-      alias: 'p',
-      default: 3000,
-      description: 'Start A Server',
-    },
-
-    inspect: {
-      type: 'boolean',
-      default: false,
-      description: 'Debug with node-inspector',
-    },
-
-    nodeFlags: {
-      type: 'string',
-    },
+  @Option({
+    alias: 'p',
+    default: 3000,
+    description: 'Start A Server',
   })
-  args: DevOption;
+  port: number;
+
+  @Option({
+    default: false,
+    description: 'Debug with node-inspector',
+  })
+  inspect: boolean;
+
+  @Option('Built-in flags in node')
+  nodeFlags: string;
+
+  @Option()
+  baseDir: string;
+
+  @Options()
+  args: any;
 
   async run() {
-    console.info('port', this.args.port);
-    console.info('inspect', this.args.inspect);
-    console.info('nodeFlags', this.args.nodeFlags);
-    console.info('baseDir', this.args.baseDir);
+    console.info('port', this.port);
+    console.info('inspect', this.inspect);
+    console.info('nodeFlags', this.nodeFlags);
+    console.info('baseDir', this.baseDir);
     return {
       command: 'dev',
       args: this.args,

--- a/test/fixtures/egg-bin/cmd/test.ts
+++ b/test/fixtures/egg-bin/cmd/test.ts
@@ -1,9 +1,4 @@
-import { DefineCommand, DefineOption, Command, Middleware, Option } from '@artus-cli/artus-cli';
-
-export interface TestOption extends Option {
-  baseDir: string;
-  file: string[]
-}
+import { DefineCommand, Option, Command, Middleware } from '@artus-cli/artus-cli';
 
 @DefineCommand({
   command: 'test <baseDir> [file...]',
@@ -11,8 +6,11 @@ export interface TestOption extends Option {
   alias: [ 't' ],
 })
 export class TestCommand extends Command {
-  @DefineOption()
-  options: TestOption;
+  @Option()
+  baseDir: string;
+
+  @Option()
+  file: string[];
 
   @Middleware([
     async (_ctx, next) => {
@@ -29,7 +27,7 @@ export class TestCommand extends Command {
     await next();
   })
   async run() {
-    console.info('test baseDir', this.options.baseDir);
-    console.info('test files', this.options.file);
+    console.info('test baseDir', this.baseDir);
+    console.info('test files', this.file);
   }
 }

--- a/test/fixtures/simple-bin/cmd/main.ts
+++ b/test/fixtures/simple-bin/cmd/main.ts
@@ -1,27 +1,21 @@
 // index.ts
-import { DefineCommand, DefineOption, Command } from '@artus-cli/artus-cli';
-
-interface Option {
-  port: number;
-  baseDir: string;
-}
+import { DefineCommand, Option, Command } from '@artus-cli/artus-cli';
 
 @DefineCommand({
   command: 'simple-bin [baseDir]',
   description: 'My Simple Bin',
 })
 export class MainCommand extends Command {
-  @DefineOption<Option>({
-    port: {
-      type: 'number',
-      alias: 'p',
-      default: 3000,
-      description: 'port',
-    },
+  @Option({
+    alias: 'p',
+    description: 'port',
   })
-  args: Option;
+  port: number;
+
+  @Option()
+  baseDir: string;
 
   async run() {
-    console.info('Run with port %s in %s', this.args.port, this.args.baseDir);
+    console.info('Run with port %s in %s', this.port, this.baseDir);
   }
 }


### PR DESCRIPTION
原来的 DefineOption 改成两个 API 

- `Options`：跟原来 `DefineOption` 差不多，主要是提供个途径可以拿到所有 args ( 包括未定义的 )
- `Option`：可以定义单个属性，也可以利用到类型反射，不用重复定义 `type` 

```typescript
import { DefineCommand, Option, Command, Middleware } from '@artus-cli/artus-cli';

@DefineCommand({
  command: 'dev [baseDir]',
  description: 'Run the development server',
  alias: [ 'd' ],
})
@Middleware(async (_ctx, next) => {
  console.info('egg-bin dev command prerun');
  await next();
  console.info('egg-bin dev command postrun');
})
export class DevCommand extends Command {
  @Option({
    alias: 'p',
    default: 3000,
    description: 'Start A Server',
  })
  port: number;

  @Option({
    default: false,
    description: 'Debug with node-inspector',
  })
  inspect: boolean;

  @Option('Built-in flags in node')
  nodeFlags: string;

  @Option()
  baseDir: string;

  async run() {
    console.info('port', this.port);
    console.info('inspect', this.inspect);
    console.info('nodeFlags', this.nodeFlags);
    console.info('baseDir', this.baseDir);
  }
}

```

