### PR TITLE
fix: should not throw when parse args

### DIFF
--- a/src/core/decorators.ts
+++ b/src/core/decorators.ts
@@ -128,7 +128,7 @@ function initOptionMeta(target: Command): OptionMeta {
         const targetCommand = parsedCommands.getCommand(ctor);
         // check target command whether is compatible with matched
         const isSameCommandOrCompatible = matched?.clz === ctor || (matched && targetCommand && checkCommandCompatible(targetCommand, matched));
-        this[optionCacheSymbol] = isSameCommandOrCompatible ? args : parsedCommands.parseArgs(argv, targetCommand);
+        this[optionCacheSymbol] = isSameCommandOrCompatible ? args : parsedCommands.parseArgs(argv, targetCommand).args;
         return this[optionCacheSymbol];
       },
 

--- a/src/core/parsed_commands.ts
+++ b/src/core/parsed_commands.ts
@@ -341,6 +341,8 @@ export class ParsedCommands {
   private _matchCommand(argv: string | string[]) {
     const result: MatchResult & { positionalArgs: Record<string, any> } = {
       fuzzyMatched: this.root,
+
+      // parse with root command without validation
       args: this.parseArgs(argv, this.root, { validateArgv: false }),
 
       // parsed positional result;
@@ -431,13 +433,11 @@ export class ParsedCommands {
     let newArgs;
 
     const result = this._matchCommand(argv);
-    if (result.matched) {
-      try {
-        // parse again with parserOption
-        newArgs = this.parseArgs(argv, result.matched);
-      } catch (e) {
-        result.error = e;
-      }
+    try {
+      // parse again with parserOption and validation
+      newArgs = this.parseArgs(argv, result.fuzzyMatched);
+    } catch (e) {
+      result.error = e;
     }
 
     // merge args and positional args

--- a/src/core/parsed_commands.ts
+++ b/src/core/parsed_commands.ts
@@ -341,9 +341,7 @@ export class ParsedCommands {
   private _matchCommand(argv: string | string[]) {
     const result: MatchResult & { positionalArgs: Record<string, any> } = {
       fuzzyMatched: this.root,
-
-      // parse with root command
-      args: this.parseArgs(argv, this.root).args,
+      args: this.parseArgs(argv).args,
 
       // parsed positional result;
       positionalArgs: {},

--- a/src/core/parsed_commands.ts
+++ b/src/core/parsed_commands.ts
@@ -434,7 +434,7 @@ export class ParsedCommands {
     result.error = result.error || parseResult.error;
 
     // merge args and positional args
-    result.args = Object.assign(parseResult.args || result.args, result.positionalArgs);
+    result.args = Object.assign(parseResult.args, result.positionalArgs);
     return result;
   }
 

--- a/src/core/parsed_commands.ts
+++ b/src/core/parsed_commands.ts
@@ -6,7 +6,7 @@ import { Injectable, Container, Inject, ScopeEnum } from '@artus/core';
 import { Middlewares } from '@artus/pipeline';
 
 import { CommandMeta, CommandConfig, OptionMeta, OptionConfig, MiddlewareConfig, MiddlewareMeta } from '../types';
-import { parseArgvToArgs, parseArgvWithPositional, parseCommand, ParsedCommandStruct, Positional } from './parser';
+import { ParseArgvOptions, parseArgvToArgs, parseArgvWithPositional, parseCommand, ParsedCommandStruct, Positional } from './parser';
 import { Command, EmptyCommand } from './command';
 import { MetadataEnum } from '../constant';
 import { BinInfo } from './bin_info';
@@ -341,7 +341,7 @@ export class ParsedCommands {
   private _matchCommand(argv: string | string[]) {
     const result: MatchResult & { positionalArgs: Record<string, any> } = {
       fuzzyMatched: this.root,
-      args: this.parseArgs(argv),
+      args: this.parseArgs(argv, this.root, { validateArgv: false }),
 
       // parsed positional result;
       positionalArgs: {},
@@ -416,10 +416,11 @@ export class ParsedCommands {
   }
 
   /** parse argv with yargs-parser */
-  parseArgs(argv: string | string[], parseCommand?: ParsedCommand) {
+  parseArgs(argv: string | string[], parseCommand?: ParsedCommand, parseOption?: ParseArgvOptions) {
     const result = parseArgvToArgs(argv, {
       optionConfig: parseCommand?.options,
       strictOptions: this.binInfo.strictOptions,
+      ...parseOption,
     });
 
     return result.argv;

--- a/src/core/parsed_commands.ts
+++ b/src/core/parsed_commands.ts
@@ -431,9 +431,7 @@ export class ParsedCommands {
 
     // parse again with parserOption and validation
     const parseResult = this.parseArgs(argv, result.fuzzyMatched);
-    if (parseResult.error) {
-      result.error = parseResult.error;
-    }
+    result.error = result.error || parseResult.error;
 
     // merge args and positional args
     result.args = Object.assign(parseResult.args || result.args, result.positionalArgs);

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -2,7 +2,12 @@ import parser from 'yargs-parser';
 import { OptionConfig } from '../types';
 import { isNil, convertValue } from '../utils';
 import { flatten } from 'lodash';
-import { errors } from '../errors';
+import { ArtusCliError, errors } from '../errors';
+
+export interface ParseResult {
+  args: any;
+  error?: ArtusCliError;
+}
 
 export interface ParsedCommandStruct {
   uid: string;
@@ -19,7 +24,6 @@ export interface Positional {
 }
 
 export interface ParseArgvOptions {
-  validateArgv?: boolean;
   strictOptions?: boolean;
   optionConfig?: OptionConfig;
 }
@@ -38,7 +42,7 @@ export function parseArgvKeySimple(argv: string | string[]) {
 }
 
 /** parse argv to args, base on yargs-parser */
-export function parseArgvToArgs(argv: string | string[], option: ParseArgvOptions = {}) {
+export function parseArgvToArgs(argv: string | string[], option: ParseArgvOptions = {}): ParseResult {
   const requiredOptions: string[] = [];
   const parserOption: parser.Options = {
     configuration: { "populate--": true },
@@ -70,28 +74,23 @@ export function parseArgvToArgs(argv: string | string[], option: ParseArgvOption
     }
   }
 
-  const result = parser.detailed(argv, parserOption);
+  const parseResult = parser.detailed(argv, parserOption);
 
-  /** skip validation */
-  if (option.validateArgv === false) {
-    return result;
-  }
-
-  const requiredNilOptions = requiredOptions.filter(k => isNil(result.argv[k]));
+  let error: ArtusCliError | undefined;
+  const requiredNilOptions = requiredOptions.filter(k => isNil(parseResult.argv[k]));
   if (requiredNilOptions.length) {
-    throw errors.required_options(requiredNilOptions);
-  }
-
-  // checking for strict options
-  if (option.optionConfig && option.strictOptions) {
+    // check required option
+    error = errors.required_options(requiredNilOptions);
+  } else if (option.optionConfig && option.strictOptions) {
+    // checking for strict options
     const argvs = parseArgvKeySimple(argv);
     const notSupportArgvs: Set<string> = new Set();
-    Object.keys(result.argv).forEach(key => {
+    Object.keys(parseResult.argv).forEach(key => {
       // _ and -- is built-in key
       if (key === '_' || key === '--') return;
 
       // checking with alias list
-      const alias = (result.aliases[key] || []).concat(key);
+      const alias = (parseResult.aliases[key] || []).concat(key);
       if (alias.every(n => !notSupportArgvs.has(n) && !option.optionConfig![n])) {
         const flag = argvs.find(a => a.parsed === key || a.raw === key)?.raw;
         if (flag) notSupportArgvs.add(flag);
@@ -100,19 +99,20 @@ export function parseArgvToArgs(argv: string | string[], option: ParseArgvOption
 
     // check unknown by yargs-parser
     argvs.forEach(a => {
-      if (result.argv[a.parsed] === undefined) notSupportArgvs.add(a.raw);
+      if (parseResult.argv[a.parsed] === undefined) notSupportArgvs.add(a.raw);
     });
 
     if (notSupportArgvs.size) {
-      throw errors.unknown_options(Array.from(notSupportArgvs));
+      error = errors.unknown_options(Array.from(notSupportArgvs));
     }
+  } else if (parseResult.error) {
+    error = errors.unknown(parseResult.error.message);
   }
 
-  if (result.error) {
-    throw errors.unknown(result.error.message);
-  }
-
-  return result;
+  return {
+    args: parseResult.argv,
+    error,
+  };
 }
 
 /** parse `<options>` or `[option]` and collect args */

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -4,11 +4,6 @@ import { isNil, convertValue } from '../utils';
 import { flatten } from 'lodash';
 import { ArtusCliError, errors } from '../errors';
 
-export interface ParseResult {
-  args: any;
-  error?: ArtusCliError;
-}
-
 export interface ParsedCommandStruct {
   uid: string;
   cmd: string;
@@ -21,11 +16,6 @@ export interface ParsedCommandStruct {
 export interface Positional {
   cmd: string;
   variadic: boolean;
-}
-
-export interface ParseArgvOptions {
-  strictOptions?: boolean;
-  optionConfig?: OptionConfig;
 }
 
 /** convert argv to camelCase key simpliy */
@@ -42,7 +32,10 @@ export function parseArgvKeySimple(argv: string | string[]) {
 }
 
 /** parse argv to args, base on yargs-parser */
-export function parseArgvToArgs(argv: string | string[], option: ParseArgvOptions = {}): ParseResult {
+export function parseArgvToArgs(argv: string | string[], option: {
+  strictOptions?: boolean;
+  optionConfig?: OptionConfig;
+} = {}) {
   const requiredOptions: string[] = [];
   const parserOption: parser.Options = {
     configuration: { "populate--": true },

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -18,6 +18,12 @@ export interface Positional {
   variadic: boolean;
 }
 
+export interface ParseArgvOptions {
+  validateArgv?: boolean;
+  strictOptions?: boolean;
+  optionConfig?: OptionConfig;
+}
+
 /** convert argv to camelCase key simpliy */
 export function parseArgvKeySimple(argv: string | string[]) {
   const list = flatten((Array.isArray(argv) ? argv : [ argv ]).map(arg => arg.split(/\s+/)));
@@ -32,10 +38,7 @@ export function parseArgvKeySimple(argv: string | string[]) {
 }
 
 /** parse argv to args, base on yargs-parser */
-export function parseArgvToArgs(argv: string | string[], option: {
-  strictOptions?: boolean;
-  optionConfig?: OptionConfig;
-} = {}) {
+export function parseArgvToArgs(argv: string | string[], option: ParseArgvOptions = {}) {
   const requiredOptions: string[] = [];
   const parserOption: parser.Options = {
     configuration: { "populate--": true },
@@ -68,6 +71,12 @@ export function parseArgvToArgs(argv: string | string[], option: {
   }
 
   const result = parser.detailed(argv, parserOption);
+
+  /** skip validation */
+  if (option.validateArgv === false) {
+    return result;
+  }
+
   const requiredNilOptions = requiredOptions.filter(k => isNil(result.argv[k]));
   if (requiredNilOptions.length) {
     throw errors.required_options(requiredNilOptions);

--- a/test/core/parsed_commands.test.ts
+++ b/test/core/parsed_commands.test.ts
@@ -37,11 +37,11 @@ describe('test/core/parsed_commands.test.ts', () => {
 
     it('parse argv', async () => {
       const devParsedCommand = parsedCommands.getCommand(DevCommand);
-      const result = parsedCommands.parseArgs('dev -p 1234 --inspect', devParsedCommand);
+      const { args: result } = parsedCommands.parseArgs('dev -p 1234 --inspect', devParsedCommand);
       assert(result.port === 1234);
       assert(result.inspect === true);
 
-      const result2 = parsedCommands.parseArgs([ 'dev' ], devParsedCommand);
+      const { args: result2 } = parsedCommands.parseArgs([ 'dev' ], devParsedCommand);
       assert(result2.port === 3000);
       assert(result2.inspect === false);
     });

--- a/test/core/parser.test.ts
+++ b/test/core/parser.test.ts
@@ -5,7 +5,7 @@ describe('test/core/parser.test.ts', () => {
   it('parseCommand', async () => {
     const r = parseCommand('dev <command> [baseDir]', 'my-bin');
     assert(r.cmd === 'dev');
-    assert.deepEqual(r.cmds, [ 'my-bin', 'dev' ]);
+    assert.deepEqual(r.cmds, ['my-bin', 'dev']);
     assert(r.demanded.length === 1);
     assert(r.demanded[0].cmd === 'command');
     assert(r.optional.length === 1);
@@ -21,7 +21,7 @@ describe('test/core/parser.test.ts', () => {
     assert(r3.demanded.length === 0);
 
     const r4 = parseCommand('$0 dev', 'my-bin');
-    assert.deepEqual(r4.cmds, [ 'my-bin', 'dev' ]);
+    assert.deepEqual(r4.cmds, ['my-bin', 'dev']);
   });
 
   it('parseArgvKeySimple', async () => {
@@ -41,104 +41,101 @@ describe('test/core/parser.test.ts', () => {
         daemon: { type: 'boolean' },
       },
     });
-    assert(r.argv.port === 123);
-    assert(r.argv.inspect === true);
-    assert(r.argv.daemon === true);
-    assert(r.argv.debug === false);
+    assert(r.args.port === 123);
+    assert(r.args.inspect === true);
+    assert(r.args.daemon === true);
+    assert(r.args.debug === false);
 
     const r2 = parseArgvToArgs('dev -c 666 -i', {
       optionConfig: {
-        port: { type: 'number', alias: [ 'p', 'c' ] },
-        inspect: { type: 'boolean', alias: [ 'i' ] },
+        port: { type: 'number', alias: ['p', 'c'] },
+        inspect: { type: 'boolean', alias: ['i'] },
         daemon: { type: 'boolean', default: true },
       },
     });
-    assert(r2.argv.port === 666);
-    assert(r2.argv.inspect === true);
-    assert(r2.argv.daemon === true);
+    assert(r2.args.port === 666);
+    assert(r2.args.inspect === true);
+    assert(r2.args.daemon === true);
 
     const r3 = parseArgvToArgs('dev -c 666 -i -- --bcd --efg', {
       optionConfig: {
-        port: { type: 'number', alias: [ 'p', 'c' ] },
-        inspect: { type: 'boolean', alias: [ 'i' ] },
+        port: { type: 'number', alias: ['p', 'c'] },
+        inspect: { type: 'boolean', alias: ['i'] },
         daemon: { type: 'boolean', default: true },
       },
     });
-    assert(r3.argv.port === 666);
-    assert.deepEqual(r3.argv['--'], [ '--bcd', '--efg' ]);
+    assert(r3.args.port === 666);
+    assert.deepEqual(r3.args['--'], ['--bcd', '--efg']);
   });
 
   it('parseArgvToArgs with unknown option', () => {
-    assert.throws(() => {
-      parseArgvToArgs('dev --port 123 --inspect --daemon --no-debug -c 666 --bbb=123', {
-        strictOptions: true,
-        optionConfig: {
-          port: { type: 'number' },
-          inspect: { type: 'boolean' },
-          daemon: { type: 'boolean' },
-        },
-      });
-    }, /Unknown options: --no-debug, -c, --bbb/);
+    const result = parseArgvToArgs('dev --port 123 --inspect --daemon --no-debug -c 666 --bbb=123', {
+      strictOptions: true,
+      optionConfig: {
+        port: { type: 'number' },
+        inspect: { type: 'boolean' },
+        daemon: { type: 'boolean' },
+      },
+    });
+    assert(result.error?.message.includes('Unknown options: --no-debug, -c, --bbb'));
 
-    assert.throws(() => {
-      parseArgvToArgs('dev --port 123 --inspect --daemon --no-debug -c 666 -bbb=123', {
-        strictOptions: true,
-        optionConfig: {
-          port: { type: 'number' },
-          inspect: { type: 'boolean' },
-          daemon: { type: 'boolean' },
-        },
-      });
-    }, /Unknown options: --no-debug, -c, -bbb/);
+    const result2 = parseArgvToArgs('dev --port 123 --inspect --daemon --no-debug -c 666 -bbb=123', {
+      strictOptions: true,
+      optionConfig: {
+        port: { type: 'number' },
+        inspect: { type: 'boolean' },
+        daemon: { type: 'boolean' },
+      },
+    });
+    assert(result2.error?.message.includes('Unknown options: --no-debug, -c, -bbb'));
 
-    assert.throws(() => {
-      parseArgvToArgs('dev --port 123 -c - -bbb=123 -- --aaa --bbb --ccc', {
-        strictOptions: true,
-        optionConfig: {
-          port: { type: 'number' },
-          inspect: { type: 'boolean' },
-          daemon: { type: 'boolean' },
-        },
-      });
-    }, /Unknown options: -c, -bbb/);
+    const result3 = parseArgvToArgs('dev --port 123 -c - -bbb=123 -- --aaa --bbb --ccc', {
+      strictOptions: true,
+      optionConfig: {
+        port: { type: 'number' },
+        inspect: { type: 'boolean' },
+        daemon: { type: 'boolean' },
+      },
+    });
+    assert(result3.error?.message.includes('Unknown options: -c, -bbb'));
   });
 
   it('parseArgvWithPositional', () => {
     const parsed = parseCommand('dev <command> [baseDir]', 'my-bin');
-    const r = parseArgvWithPositional([ 'module', './' ], parsed.demanded);
+    const r = parseArgvWithPositional(['module', './'], parsed.demanded);
     assert(!r.unmatchPositionals.length);
-    assert.deepEqual(r.unknownArgv, [ './' ]);
+    assert.deepEqual(r.unknownArgv, ['./']);
     assert(r.result.command === 'module');
 
-    const r2 = parseArgvWithPositional([ './' ], parsed.optional);
+    const r2 = parseArgvWithPositional(['./'], parsed.optional);
     assert.deepEqual(r2.unknownArgv, []);
     assert(r2.result.baseDir === './');
 
     // variadic demanded
     const parsed2 = parseCommand('dev <command..>', 'my-bin');
-    const r3 = parseArgvWithPositional([ 'module', 'module2', 'module3' ], parsed2.demanded);
-    assert.deepEqual(r3.result.command, [ 'module', 'module2', 'module3' ]);
+    const r3 = parseArgvWithPositional(['module', 'module2', 'module3'], parsed2.demanded);
+    assert.deepEqual(r3.result.command, ['module', 'module2', 'module3']);
 
     // varidic optional
     const parsed3 = parseCommand('dev [command..]', 'my-bin');
-    const r4 = parseArgvWithPositional([ 'module', 'module2', 'module3' ], parsed3.optional);
-    assert.deepEqual(r4.result.command, [ 'module', 'module2', 'module3' ]);
+    const r4 = parseArgvWithPositional(['module', 'module2', 'module3'], parsed3.optional);
+    assert.deepEqual(r4.result.command, ['module', 'module2', 'module3']);
 
     // varidic optional style 2
     const parsed31 = parseCommand('dev [...command]', 'my-bin');
-    const r41 = parseArgvWithPositional([ 'module', 'module2', 'module3' ], parsed31.optional);
-    assert.deepEqual(r41.result.command, [ 'module', 'module2', 'module3' ]);
+    const r41 = parseArgvWithPositional(['module', 'module2', 'module3'], parsed31.optional);
+    assert.deepEqual(r41.result.command, ['module', 'module2', 'module3']);
 
     // not enough arguments
     const parsed4 = parseCommand('dev <option1> <option2> <option3>', 'my-bin');
-    const r5 = parseArgvWithPositional([ 'module', 'module2' ], parsed4.demanded);
+    const r5 = parseArgvWithPositional(['module', 'module2'], parsed4.demanded);
     assert(r5.result.option1 == 'module');
     assert(r5.result.option2 == 'module2');
     assert(r5.unmatchPositionals.length);
 
     // convert type
     const parsed5 = parseCommand('dev <option1> <option2>', 'my-bin');
-    const r6 = parseArgvWithPositional([ '11', '22' ], parsed5.demanded, {
+    const r6 = parseArgvWithPositional(['11', '22'], parsed5.demanded, {
       option1: { type: 'number' },
       option2: { type: 'string' },
     });

--- a/test/fixtures/argument-bin/special.ts
+++ b/test/fixtures/argument-bin/special.ts
@@ -1,4 +1,4 @@
-import { DefineCommand, Option, Command } from '@artus-cli/artus-cli';
+import { DefineCommand, Options, Command } from '@artus-cli/artus-cli';
 
 interface Option {
   baseDir: string;
@@ -8,7 +8,7 @@ interface Option {
   command: 'dev [baseDir]',
 })
 export class ArgumentDevComand extends Command {
-  @Option<Option>({
+  @Options<Option>({
     baseDir: { type: 'string' },
   })
   opt: Option;
@@ -26,7 +26,7 @@ interface DebugOption {
   command: 'debug',
 })
 export class ArgumentDebugComand extends ArgumentDevComand {
-  @Option<DebugOption>({
+  @Options<DebugOption>({
     port: { type: 'number' },
   })
   argv: DebugOption;

--- a/test/fixtures/egg-bin/cmd/main.ts
+++ b/test/fixtures/egg-bin/cmd/main.ts
@@ -1,8 +1,17 @@
-import { DefineCommand, Command } from '@artus-cli/artus-cli';
+import { DefineCommand, Command, Option } from '@artus-cli/artus-cli';
 
 @DefineCommand()
 export class MainCommand extends Command {
+  @Option({
+    alias: 'c',
+  })
+  cwd?: string;
+
   async run() {
+    if (this.cwd) {
+      return console.info('main in', this.cwd);
+    }
+
     console.info('main');
   }
 }

--- a/test/fixtures/required-args/bin/cli.ts
+++ b/test/fixtures/required-args/bin/cli.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { start } from '@artus-cli/artus-cli';
+
+start();

--- a/test/fixtures/required-args/index.ts
+++ b/test/fixtures/required-args/index.ts
@@ -1,0 +1,20 @@
+import { DefineCommand, Option, Command } from '@artus-cli/artus-cli';
+
+interface Option {
+  port?: number;
+  inspect?: boolean;
+}
+
+@DefineCommand({
+  command: '$0 <port>',
+})
+export class ArgumentMainComand extends Command {
+  @Option({
+    alias: 'i',
+  })
+  inspect: boolean;
+
+  async run() {
+    console.info('main');
+  }
+}

--- a/test/fixtures/required-args/package.json
+++ b/test/fixtures/required-args/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "required-args",
+  "type": "commonjs",
+  "bin": "./index.js"
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -7,6 +7,11 @@ describe('test/index.test.ts', () => {
       .expect('stdout', /Usage: egg-bin/)
       .end();
 
+    await fork('egg-bin', [ '-h' ])
+      .debug()
+      .expect('stdout', /Usage: egg-bin/)
+      .end();
+
     await fork('egg-bin', [ 'dev', '123', '-p=6000' ])
       .debug()
       .expect('stdout', /port 6000/)
@@ -32,7 +37,7 @@ describe('test/index.test.ts', () => {
     await fork('egg-bin', [ 'test', './' ])
       .debug()
       .expect('stderr', /not match test files/)
-      .expect('code', 2)
+      .expect('code', 1)
       .end();
 
     await fork('egg-bin', [ 'test', 'mock-error', 'file1' ])
@@ -47,6 +52,18 @@ describe('test/index.test.ts', () => {
       .expect('stdout', /test command middleware 1\ntest command middleware 2\ntest command middleware 3/)
       .expect('stdout', /test baseDir .\//)
       .expect('stdout', /test files \[ 'file1', 'file2' \]/)
+      .end();
+  });
+
+  it('egg-bin should work with root flags', async () => {
+    await fork('egg-bin', [ '--cwd', './' ])
+      .debug()
+      .expect('stdout', /main in .\//)
+      .end();
+
+    await fork('egg-bin', [ '-c', 'foo' ])
+      .debug()
+      .expect('stdout', /main in foo/)
       .end();
   });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -37,7 +37,7 @@ describe('test/index.test.ts', () => {
     await fork('egg-bin', [ 'test', './' ])
       .debug()
       .expect('stderr', /not match test files/)
-      .expect('code', 1)
+      .expect('code', 2)
       .end();
 
     await fork('egg-bin', [ 'test', 'mock-error', 'file1' ])

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -198,4 +198,11 @@ describe('test/index.test.ts', () => {
       .expect('stdout', /-p, --port number/)
       .end();
   });
+
+  it('required-args should work', async () => {
+    await fork('required-args', [ '-h' ])
+      .debug()
+      .expect('stdout', /Usage: required-args \<port\>/)
+      .end();
+  });
 });


### PR DESCRIPTION
parseArgv 的时候不抛错，不然如果配了比如 `my-bin <url>` 这种配置，再执行 `my-bin -h` 的时候，parseArgv 抛错从而导致 args 中就不带对 `-h` 转换成 `--help` 的处理。

所以纵使 parseArgv 跪了，也得把新解析的 args 更新了

> 子指令也有一样的情况