### PR TITLE
feat: support enable config in DefineCommand

### DIFF
--- a/src/core/command.ts
+++ b/src/core/command.ts
@@ -18,6 +18,6 @@ export abstract class Command {
 @Injectable()
 export class EmptyCommand extends Command {
   async run() {
-    // nothing
+    throw new Error('should not call empty command');
   }
 }

--- a/src/core/parsed_commands.ts
+++ b/src/core/parsed_commands.ts
@@ -57,6 +57,7 @@ export class ParsedCommand implements ParsedCommandStruct {
   /** user defined in options but remove bin name */
   command: string;
   alias: string[];
+  enable: boolean;
   demanded: Positional[];
   optional: Positional[];
   description: string;
@@ -99,6 +100,7 @@ export class ParsedCommand implements ParsedCommandStruct {
     // read from command config
     this.commandConfig = commandConfig;
     this.description = commandConfig.description || '';
+    this.enable = typeof commandConfig.enable === 'boolean' ? commandConfig.enable : true;
     this.alias = commandConfig.alias
       ? Array.isArray(commandConfig.alias)
         ? commandConfig.alias
@@ -356,7 +358,7 @@ export class ParsedCommands {
     for (; index < wholeArgv.length; index++) {
       const el = wholeArgv[index];
       const nextMatch = result.fuzzyMatched.childs.find(c => (
-        c.cmd === el || c.alias.includes(el)
+        c.enable && (c.cmd === el || c.alias.includes(el))
       ));
 
       if (nextMatch) {

--- a/src/core/parsed_commands.ts
+++ b/src/core/parsed_commands.ts
@@ -124,7 +124,7 @@ export class ParsedCommand implements ParsedCommandStruct {
   }
 
   get isRunable() {
-    return this.clz !== EmptyCommand;
+    return this.clz !== EmptyCommand && this.enable;
   }
 
   get depth() {
@@ -408,7 +408,7 @@ export class ParsedCommands {
     result.matched = result.fuzzyMatched;
     debug('Final match result is %s', result.matched.clz.name);
 
-    // match empty command
+    // match empty command or not enable command
     if (!result.matched.isRunable && this.binInfo.strictCommands) {
       result.error = errors.command_is_not_implement(`${this.binInfo.binName}${printArgv ? ` ${printArgv}` : ''}`);
       debug(result.error.message);

--- a/src/core/program.ts
+++ b/src/core/program.ts
@@ -63,6 +63,18 @@ export class Program {
     effectCommands.forEach(c => this.getParsedCommand(c)?.updateGlobalOptions(opt));
   }
 
+  /** disable command dynamically */
+  disableCommand(clz: MaybeParsedCommand) {
+    const parsedCommand = this.getParsedCommand(clz);
+    if (parsedCommand) parsedCommand.enable = false;
+  }
+
+  /** enable command dynamically */
+  enableCommand(clz: MaybeParsedCommand) {
+    const parsedCommand = this.getParsedCommand(clz);
+    if (parsedCommand) parsedCommand.enable = true;
+  }
+
   /** register pipeline middleware */
   use(fn: MiddlewareInput) {
     return this.trigger.use(fn);

--- a/src/core/trigger.ts
+++ b/src/core/trigger.ts
@@ -20,7 +20,7 @@ export class CommandTrigger extends Trigger {
 
       // match error, throw
       if (error) throw error;
-      if (!matched) {
+      if (!matched || !matched.isRunable) {
         debug('Can not match any command, exit...');
         return;
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,8 @@ import { Command } from './core/command';
 import { Middleware, Middlewares } from '@artus/pipeline';
 
 export interface CommandConfig extends Record<string, any> {
+  /** whether enable command, default to true */
+  enable?: boolean;
   /** a string representing the command */
   command?: string;
   /** command description */

--- a/test/fixtures/dynamic/bin/cli.ts
+++ b/test/fixtures/dynamic/bin/cli.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+import { start } from '@artus-cli/artus-cli';
+import path from 'path';
+
+start({ baseDir: path.dirname(__dirname) });

--- a/test/fixtures/dynamic/index.ts
+++ b/test/fixtures/dynamic/index.ts
@@ -1,0 +1,20 @@
+import { DefineCommand, Command } from '@artus-cli/artus-cli';
+
+@DefineCommand({
+  enable: false,
+  command: 'dev [baseDir]',
+})
+export class ArgumentDevComand extends Command {
+  async run() {
+    console.info('dev command');
+  }
+}
+
+@DefineCommand({
+  command: 'debug',
+})
+export class ArgumentDebugComand extends ArgumentDevComand {
+  async run() {
+    console.info('debug command');
+  }
+}

--- a/test/fixtures/dynamic/lifecycle.ts
+++ b/test/fixtures/dynamic/lifecycle.ts
@@ -1,0 +1,19 @@
+import { Program } from '@artus-cli/artus-cli';
+import { ArgumentDevComand, ArgumentDebugComand } from './';
+import { Inject, ApplicationLifecycle, LifecycleHook, LifecycleHookUnit } from '@artus/core';
+
+@LifecycleHookUnit()
+export default class Lifecycle implements ApplicationLifecycle {
+  @Inject()
+  private program: Program;
+
+  @LifecycleHook()
+  async configDidLoad() {
+    if (process.env.ENABLE_DEV) {
+      this.program.enableCommand(ArgumentDevComand);
+    }
+    if (process.env.DISABLE_DEBUG) {
+      this.program.disableCommand(ArgumentDebugComand);
+    }
+  }
+}

--- a/test/fixtures/dynamic/package.json
+++ b/test/fixtures/dynamic/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "dynamic",
+  "type": "commonjs",
+  "bin": "./index.js"
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -205,4 +205,34 @@ describe('test/index.test.ts', () => {
       .expect('stdout', /Usage: required-args \<port\>/)
       .end();
   });
+
+  it('dynamic should work', async () => {
+    // dev should not work
+    await fork('dynamic', [ 'dev' ])
+      .debug()
+      .expect('stderr', /Command is not found: 'dynamic dev'/)
+      .end();
+
+    // enable dev
+    await fork('dynamic', [ 'dev' ], {
+      env: { ...process.env, ENABLE_DEV: 'true' },
+    })
+      .debug()
+      .expect('stdout', /dev command/)
+      .end();
+
+    // debug should work
+    await fork('dynamic', [ 'debug' ])
+      .debug()
+      .expect('stdout', /debug command/)
+      .end();
+    
+    // disable debug
+    await fork('dynamic', [ 'debug' ], {
+      env: { ...process.env, DISABLE_DEBUG: 'true' },
+    })
+      .debug()
+      .expect('stderr', /Command is not found: 'dynamic debug'/)
+      .end();
+  });
 });


### PR DESCRIPTION
DefineCommand 支持配置 `enable` ，方便在 lifecycle 中能通过 `program` 动态开关对应 Command （ 比如根据 config 配置是否启用某个指令 ）