### PR TITLE
feat: add examples args

### DIFF
--- a/src/core/parsed_commands.ts
+++ b/src/core/parsed_commands.ts
@@ -10,7 +10,7 @@ import { parseArgvToArgs, parseArgvWithPositional, parseCommand, ParsedCommandSt
 import { Command, EmptyCommand } from './command';
 import { MetadataEnum } from '../constant';
 import { BinInfo } from './bin_info';
-import { isInheritFrom } from '../utils';
+import { isInheritFrom, formatToArray } from '../utils';
 import { errors, ArtusCliError } from '../errors';
 
 const OPTION_SYMBOL = Symbol('ParsedCommand#Option');
@@ -61,6 +61,7 @@ export class ParsedCommand implements ParsedCommandStruct {
   demanded: Positional[];
   optional: Positional[];
   description: string;
+  examples: string[];
   globalOptions?: OptionConfig;
   flagOptions: OptionConfig;
   argumentOptions: OptionConfig;
@@ -100,12 +101,9 @@ export class ParsedCommand implements ParsedCommandStruct {
     // read from command config
     this.commandConfig = commandConfig;
     this.description = commandConfig.description || '';
+    this.examples = formatToArray(commandConfig.examples);
     this.enable = typeof commandConfig.enable === 'boolean' ? commandConfig.enable : true;
-    this.alias = commandConfig.alias
-      ? Array.isArray(commandConfig.alias)
-        ? commandConfig.alias
-        : [ commandConfig.alias ]
-      : [];
+    this.alias = formatToArray(commandConfig.alias);
 
     // middleware config
     this.commandMiddlewares = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,11 @@ export async function start(options: ArtusCliOptions = {}) {
   const { pkgInfo, pkgPath } = await readPkg(findPkgDir);
   const baseDir = options.baseDir || path.dirname(pkgPath);
 
+  // auto use package.json bin
+  if (!options.binName && typeof pkgInfo.bin === 'object') {
+    options.binName = Object.keys(pkgInfo.bin)[0];
+  }
+
   // record scanning state
   process.env.ARTUS_CLI_SCANNING = 'true';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export async function start(options: ArtusCliOptions = {}) {
   const baseDir = options.baseDir || path.dirname(pkgPath);
 
   // auto use package.json bin
-  if (!options.binName && typeof pkgInfo.bin === 'object') {
+  if (!options.binName && pkgInfo.bin && typeof pkgInfo.bin === 'object') {
     options.binName = Object.keys(pkgInfo.bin)[0];
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,8 @@ export interface CommandConfig extends Record<string, any> {
   command?: string;
   /** command description */
   description?: string;
+  /** command usage examples */
+  examples?: string | string[];
   /** command alias */
   alias?: string | string[];
   /** parent command */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,3 +87,11 @@ export function getCalleeDir(stackIndex: number): string | undefined {
 function prepareObjectStackTrace(_obj, stack) {
   return stack;
 }
+
+export function formatToArray<T>(input?: T | T[]): T[] {
+  return input
+    ? Array.isArray(input)
+      ? input
+      : [ input ]
+    : [];
+}

--- a/test/core/parsed_commands.test.ts
+++ b/test/core/parsed_commands.test.ts
@@ -203,7 +203,13 @@ describe('test/core/parsed_commands.test.ts', () => {
     const beforeFn = async () => 1;
     const afterFn = async () => 1;
 
-    @DefineCommand({ command: 'dev [baseDir]', description: '666' })
+    @DefineCommand({
+      command: 'dev [baseDir]',
+      description: '666',
+      examples: [
+        'my-bin dev ./',
+      ],
+    })
     @Middleware(async () => 1)
     class MyCommand extends Command {
       @Options({
@@ -264,6 +270,7 @@ describe('test/core/parsed_commands.test.ts', () => {
     const tree = new ParsedCommandTree('my-bin', [ MyCommand, NewMyCommand, OverrideMyCommand ]);
     const parsedMyCommand = tree.get(MyCommand)!;
     assert(parsedMyCommand.location === __filename);
+    assert(parsedMyCommand.examples[0] === 'my-bin dev ./');
     assert(parsedMyCommand.uid === 'my-bin dev');
     assert(parsedMyCommand.clz === MyCommand);
     assert(parsedMyCommand.cmd === 'dev');

--- a/test/fixtures/simple-bin/cmd/main.ts
+++ b/test/fixtures/simple-bin/cmd/main.ts
@@ -2,7 +2,7 @@
 import { DefineCommand, Option, Command } from '@artus-cli/artus-cli';
 
 @DefineCommand({
-  command: 'simple-bin [baseDir]',
+  command: '$0 [baseDir]',
   description: 'My Simple Bin',
 })
 export class MainCommand extends Command {

--- a/test/fixtures/simple-bin/package.json
+++ b/test/fixtures/simple-bin/package.json
@@ -1,5 +1,7 @@
 {
   "name": "simple-bin",
   "type": "commonjs",
-  "bin": "./bin/cli.js"
+  "bin": {
+    "simple": "./bin/cli.js"
+  }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -132,7 +132,7 @@ describe('test/index.test.ts', () => {
   it('simple-bin should work', async () => {
     await fork('simple-bin', [ '--help' ])
       .debug()
-      .expect('stdout', /Usage: simple-bin \[baseDir\]/)
+      .expect('stdout', /Usage: simple \[baseDir\]/)
       .expect('stdout', /-p, --port/)
       .expect('stdout', /-h, --help/)
       .end();


### PR DESCRIPTION
- 支持 DefinedComand 时传入 examples 字段（ 用于在 help 指令中打印用法 ）
- 支持自动根据 package.json 中的 bin 字段读取 binName