### PR TITLE
refactor: optimize parse_commands logic

### DIFF
--- a/src/core/parsed_command.ts
+++ b/src/core/parsed_command.ts
@@ -1,0 +1,126 @@
+import { Middlewares } from '@artus/pipeline';
+import { CommandConfig, OptionConfig, MiddlewareConfig, ExampleItem } from '../types';
+import { ParsedCommandStruct, Positional } from './parser';
+import { Command, EmptyCommand } from './command';
+const OPTION_SYMBOL = Symbol('ParsedCommand#Option');
+
+export interface ParsedCommandOption {
+  location?: string;
+  commandConfig: FormattedCommandConfig;
+  optionConfig?: {
+    flagOptions: OptionConfig;
+    argumentOptions: OptionConfig;
+  };
+}
+
+export interface FormattedCommandConfig {
+  enable: boolean;
+  command: string;
+  description: string;
+  examples: ExampleItem[];
+  alias: string[];
+  parsedCommandInfo: ParsedCommandStruct;
+  originalCommandConfig: CommandConfig;
+}
+
+/** Wrapper of command */
+export class ParsedCommand implements ParsedCommandStruct {
+  /** cmds.join(' ') */
+  uid: string;
+  /** the last element of cmds, 'bin dev' is 'dev', 'bin module test [baseDir]' is 'test' */
+  cmd: string;
+  /** convert command to array, like [ 'bin', 'dev' ] */
+  cmds: string[];
+  /** user defined in options but remove bin name */
+  command: string;
+  alias: string[];
+  enable: boolean;
+  demanded: Positional[];
+  optional: Positional[];
+  description: string;
+  examples: ExampleItem[];
+  globalOptions?: OptionConfig;
+  flagOptions: OptionConfig;
+  argumentOptions: OptionConfig;
+  /** Command class location */
+  location?: string;
+
+  /** child commands */
+  childs: ParsedCommand[];
+  /** parent command */
+  parent: ParsedCommand | null;
+  /** inherit command */
+  inherit: ParsedCommand | null;
+
+  commandConfig: CommandConfig;
+  commandMiddlewares: Middlewares;
+  executionMiddlewares: Middlewares;
+
+  constructor(public clz: typeof Command, option: ParsedCommandOption) {
+    const { location, commandConfig, optionConfig } = option;
+    const { parsedCommandInfo } = commandConfig;
+    this.location = location;
+
+    // read from parsed_command
+    this.uid = parsedCommandInfo.uid;
+    this.command = parsedCommandInfo.command;
+    this.cmd = parsedCommandInfo.cmd;
+    this.cmds = parsedCommandInfo.cmds;
+    this.demanded = parsedCommandInfo.demanded;
+    this.optional = parsedCommandInfo.optional;
+
+    // read from option config
+    this.flagOptions = optionConfig?.flagOptions || {};
+    this.argumentOptions = optionConfig?.argumentOptions || {};
+    this.childs = [];
+    this.parent = null;
+    this.inherit = null;
+
+    // read from command config
+    this.commandConfig = commandConfig.originalCommandConfig;
+    this.description = commandConfig.description;
+    this.examples = commandConfig.examples;
+    this.enable = commandConfig.enable;
+    this.alias = commandConfig.alias;
+
+    // middleware config
+    this.commandMiddlewares = [];
+    this.executionMiddlewares = [];
+  }
+
+  get options(): OptionConfig {
+    if (!this[OPTION_SYMBOL]) {
+      this[OPTION_SYMBOL] = { ...this.globalOptions, ...this.flagOptions };
+    }
+    return this[OPTION_SYMBOL];
+  }
+
+  get isRoot() {
+    return !this.parent;
+  }
+
+  get isRunable() {
+    return this.clz !== EmptyCommand && this.enable;
+  }
+
+  get depth() {
+    return this.cmds.length;
+  }
+
+  addMiddlewares(type: 'command' | 'execution', config: MiddlewareConfig) {
+    const { middleware, mergeType } = config;
+    const middlewares = type === 'command' ? this.commandMiddlewares : this.executionMiddlewares;
+    const extraMiddlewares = Array.isArray(middleware) ? middleware : [ middleware ];
+    // mergeType default is after
+    if (!mergeType || mergeType === 'after') {
+      middlewares.push(...extraMiddlewares);
+    } else {
+      middlewares.unshift(...extraMiddlewares);
+    }
+  }
+
+  updateGlobalOptions(opt: OptionConfig) {
+    this.globalOptions = { ...this.globalOptions, ...opt };
+    this[OPTION_SYMBOL] = null;
+  }
+}

--- a/src/core/parsed_command_tree.ts
+++ b/src/core/parsed_command_tree.ts
@@ -53,15 +53,14 @@ export class ParsedCommandTree {
 
   private formatCommandConfig(config: CommandConfig, parent?: ParsedCommand): FormattedCommandConfig {
     const binName = this.binInfo.binName;
-    const obj = this.descObj;
-
+    const descObj = this.descObj;
     const prefix = parent?.cmds.join(' ');
-    const command = formatCmd(config.command || '', obj, prefix);
+    const command = formatCmd(config.command || '', descObj, prefix);
     const examples = formatToArray(config.examples).map(info => {
       const items = typeof info === 'string' ? [ info ] : info;
       return {
-        command: formatCmd(items[0], obj, prefix),
-        description: items[1] ? formatDesc(items[1], obj) : undefined,
+        command: formatCmd(items[0], descObj, prefix),
+        description: items[1] ? formatDesc(items[1], descObj) : undefined,
       };
     });
 
@@ -71,7 +70,7 @@ export class ParsedCommandTree {
       enable: typeof config.enable === 'boolean' ? config.enable : true,
       examples,
       alias: formatToArray(config.alias),
-      description: formatDesc(config.description || '', obj),
+      description: formatDesc(config.description || '', descObj),
       originalCommandConfig: config,
       parsedCommandInfo,
     };

--- a/src/core/parsed_command_tree.ts
+++ b/src/core/parsed_command_tree.ts
@@ -1,0 +1,220 @@
+import { debuglog } from 'node:util';
+import assert from 'node:assert';
+import { Injectable, Inject, ScopeEnum } from '@artus/core';
+import { CommandMeta, CommandConfig, OptionMeta, OptionConfig, MiddlewareMeta } from '../types';
+import { parseCommand } from './parser';
+import { Command, EmptyCommand } from './command';
+import { MetadataEnum } from '../constant';
+import { isInheritFrom, formatToArray, formatCmd, formatDesc } from '../utils';
+import { errors } from '../errors';
+import { ParsedCommand, FormattedCommandConfig } from './parsed_command';
+import { BinInfo } from './bin_info';
+const debug = debuglog('artus-cli#ParsedCommands');
+
+/** Parsed Command Tree */
+@Injectable({ scope: ScopeEnum.SINGLETON })
+export class ParsedCommandTree {
+  @Inject()
+  private readonly binInfo: BinInfo;
+
+  /** root of command tree */
+  root: ParsedCommand | undefined;
+
+  /** command list, the key is command string used to match argv */
+  commands: Map<string, ParsedCommand> = new Map();
+
+  /** cache the instance of parsedCommand */
+  parsedCommandMap: Map<typeof Command, ParsedCommand> = new Map();
+
+  private get descObj() {
+    return {
+      ...this.binInfo,
+      $0: this.binInfo.binName,
+      bin: this.binInfo.binName,
+    };
+  }
+
+  private formatOptions(option: OptionConfig, argumentsKey: string[]) {
+    const descObj = this.descObj;
+    const flagOptions: OptionConfig = {};
+    const argumentOptions: OptionConfig = {};
+    Object.keys(option).forEach(key => {
+      const obj = argumentsKey.includes(key) ? argumentOptions : flagOptions;
+      const config = obj[key] = { ...option[key] };
+      if (config.description) {
+        config.description = formatDesc(config.description, descObj);
+      }
+    });
+
+    return {
+      flagOptions, argumentOptions,
+    };
+  }
+
+  private formatCommandConfig(config: CommandConfig, parent?: ParsedCommand): FormattedCommandConfig {
+    const binName = this.binInfo.binName;
+    const obj = this.descObj;
+
+    const prefix = parent?.cmds.join(' ');
+    const command = formatCmd(config.command || '', obj, prefix);
+    const examples = formatToArray(config.examples).map(info => {
+      const items = typeof info === 'string' ? [ info ] : info;
+      return {
+        command: formatCmd(items[0], obj, prefix),
+        description: items[1] ? formatDesc(items[1], obj) : undefined,
+      };
+    });
+
+    const parsedCommandInfo = parseCommand(command, binName);
+    return {
+      command,
+      enable: typeof config.enable === 'boolean' ? config.enable : true,
+      examples,
+      alias: formatToArray(config.alias),
+      description: formatDesc(config.description || '', obj),
+      originalCommandConfig: config,
+      parsedCommandInfo,
+    };
+  }
+
+  /** convert Command class to ParsedCommand instance */
+  private initParsedCommand(clz: typeof Command) {
+    const metadata = Reflect.getOwnMetadata(MetadataEnum.COMMAND, clz) as CommandMeta;
+    if (!metadata) return;
+
+    // avoid creating parsedCommand again.
+    if (this.parsedCommandMap.has(clz)) {
+      return this.parsedCommandMap.get(clz);
+    }
+
+    const commandMeta = metadata;
+    const inheritClass = Object.getPrototypeOf(clz);
+    const inheritCommand = this.initParsedCommand(inheritClass);
+    let commandConfig = { ...commandMeta.config };
+
+    // mege command config with inherit command
+    if (inheritCommand && commandMeta.inheritMetadata !== false) {
+      const inheritCommandConfig = inheritCommand.commandConfig;
+      commandConfig = Object.assign({}, {
+        alias: inheritCommandConfig.alias,
+        command: inheritCommandConfig.command,
+        description: inheritCommandConfig.description,
+        parent: inheritCommandConfig.parent,
+      } satisfies CommandConfig, commandConfig);
+    }
+
+    // init parent
+    let parentCommand: ParsedCommand | undefined;
+    if (commandConfig.parent) {
+      parentCommand = this.initParsedCommand(commandConfig.parent);
+      assert(parentCommand, `parent ${commandConfig.parent?.name} is not a valid Command`);
+    }
+
+    // format command config
+    const formattedCommandConfig = this.formatCommandConfig(commandConfig, parentCommand);
+    const parsedCommandInfo = formattedCommandConfig.parsedCommandInfo;
+
+    // split options with argument key and merge option info with inherit command
+    const optionMeta: OptionMeta | undefined = Reflect.getOwnMetadata(MetadataEnum.OPTION, clz);
+    const argumentsKey = parsedCommandInfo.demanded.concat(parsedCommandInfo.optional).map(pos => pos.cmd);
+    let { flagOptions, argumentOptions } = this.formatOptions(optionMeta?.config || {}, argumentsKey);
+    if (inheritCommand && optionMeta?.inheritMetadata !== false) {
+      flagOptions = Object.assign({}, inheritCommand.flagOptions, flagOptions);
+      argumentOptions = Object.assign({}, inheritCommand.argumentOptions, argumentOptions);
+    }
+
+    const parsedCommand = new ParsedCommand(clz, {
+      location: commandMeta.location,
+      commandConfig: formattedCommandConfig,
+      optionConfig: { flagOptions, argumentOptions },
+    });
+
+    if (inheritCommand) parsedCommand.inherit = inheritCommand;
+    if (this.commands.has(parsedCommandInfo.uid)) {
+      const existsParsedCommand = this.commands.get(parsedCommandInfo.uid)!;
+
+      // override only allow in class inheritance or options.override=true
+      const err = errors.command_is_conflict(existsParsedCommand.command, existsParsedCommand.clz.name, existsParsedCommand.location, parsedCommand.clz.name, parsedCommand.location);
+      if (!commandMeta.overrideCommand && !isInheritFrom(parsedCommand.clz, existsParsedCommand.clz)) {
+        throw err;
+      }
+
+      debug(err.message);
+    }
+
+    // handle middlewares
+    // Default orders:
+    //
+    // In class inheritance:
+    //              command1  <-extend-  command2
+    // trigger --> middleware1   -->   middleware2 --> middleware3  --> run
+    //
+    // ------------
+    //
+    // In run method:
+    //                      command2                               command1
+    // trigger --> middleware2 --> middleware3 --> run --> middleware1 --> super.run
+
+    // merge command middlewares with inherit command
+    const middlewareMeta = Reflect.getOwnMetadata(MetadataEnum.MIDDLEWARE, clz) as (MiddlewareMeta | undefined);
+    const commandMiddlewareConfigList = middlewareMeta?.configList || [];
+    if (inheritCommand && middlewareMeta?.inheritMetadata !== false) {
+      parsedCommand.addMiddlewares('command', { middleware: inheritCommand.commandMiddlewares });
+    }
+    commandMiddlewareConfigList.forEach(config => parsedCommand.addMiddlewares('command', config));
+
+    // add run middlewares, no need to merge with inherit command
+    const executionMiddlewareConfig = Reflect.getOwnMetadata(MetadataEnum.RUN_MIDDLEWARE, clz) as (MiddlewareMeta | undefined);
+    const executionMiddlewareConfigList = executionMiddlewareConfig?.configList || [];
+    executionMiddlewareConfigList.forEach(config => parsedCommand.addMiddlewares('execution', config));
+
+    // cache the instance
+    this.commands.set(parsedCommandInfo.uid, parsedCommand);
+    this.parsedCommandMap.set(clz, parsedCommand);
+    return parsedCommand;
+  }
+
+  public build(commandList: Array<typeof Command>) {
+    this.root = undefined;
+    this.commands.clear();
+    this.parsedCommandMap.clear();
+
+    const parsedCommands = commandList
+      .map(clz => this.initParsedCommand(clz))
+      .filter(c => !!c) as ParsedCommand[];
+
+    // handle parent and childs
+    parsedCommands
+      .sort((a, b) => a.depth - b.depth)
+      .forEach(parsedCommand => {
+        let parent: ParsedCommand | undefined;
+        parsedCommand.cmds.forEach(cmd => {
+          // fullCmd is the key of this.commands
+          const fullCmd = parent ? parent.cmds.concat(cmd).join(' ') : cmd;
+
+          let cacheParsedCommand = this.commands.get(fullCmd);
+          if (!cacheParsedCommand) {
+            // create empty node
+            debug('Create empty command for \'%s\'', fullCmd);
+            cacheParsedCommand = new ParsedCommand(EmptyCommand, {
+              commandConfig: this.formatCommandConfig({ command: fullCmd }),
+            });
+            this.commands.set(fullCmd, cacheParsedCommand);
+          }
+
+          if (!parent) {
+            this.root = parent = cacheParsedCommand;
+            return;
+          }
+
+          cacheParsedCommand.parent = parent;
+          parent.childs.push(cacheParsedCommand);
+          parent = cacheParsedCommand;
+        });
+      });
+  }
+
+  get(clz: typeof Command) {
+    return this.parsedCommandMap.get(clz);
+  }
+}

--- a/src/core/parsed_commands.ts
+++ b/src/core/parsed_commands.ts
@@ -1,19 +1,13 @@
 import { debuglog } from 'node:util';
-import { assert } from 'node:console';
-
-import { pick, omit } from 'lodash';
 import { Injectable, Container, Inject, ScopeEnum } from '@artus/core';
-import { Middlewares } from '@artus/pipeline';
-
-import { CommandMeta, CommandConfig, OptionMeta, OptionConfig, MiddlewareConfig, MiddlewareMeta } from '../types';
-import { parseArgvToArgs, parseArgvWithPositional, parseCommand, ParsedCommandStruct, Positional } from './parser';
-import { Command, EmptyCommand } from './command';
+import { parseArgvToArgs, parseArgvWithPositional } from './parser';
+import { Command } from './command';
 import { MetadataEnum } from '../constant';
 import { BinInfo } from './bin_info';
-import { isInheritFrom, formatToArray } from '../utils';
 import { errors, ArtusCliError } from '../errors';
+import { ParsedCommand } from './parsed_command';
+import { ParsedCommandTree } from './parsed_command_tree';
 
-const OPTION_SYMBOL = Symbol('ParsedCommand#Option');
 const TREE_SYMBOL = Symbol('ParsedCommand#Tree');
 const debug = debuglog('artus-cli#ParsedCommands');
 
@@ -36,282 +30,6 @@ export interface MatchResult {
   args: Record<string, any>;
 }
 
-export interface ParsedCommandOption {
-  location?: string;
-  commandConfig: CommandConfig;
-  parsedCommandInfo: ParsedCommandStruct;
-  optionConfig?: {
-    flagOptions: OptionConfig;
-    argumentOptions: OptionConfig;
-  };
-}
-
-/** Wrapper of command */
-export class ParsedCommand implements ParsedCommandStruct {
-  /** cmds.join(' ') */
-  uid: string;
-  /** the last element of cmds, 'bin dev' is 'dev', 'bin module test [baseDir]' is 'test' */
-  cmd: string;
-  /** convert command to array, like [ 'bin', 'dev' ] */
-  cmds: string[];
-  /** user defined in options but remove bin name */
-  command: string;
-  alias: string[];
-  enable: boolean;
-  demanded: Positional[];
-  optional: Positional[];
-  description: string;
-  examples: string[];
-  globalOptions?: OptionConfig;
-  flagOptions: OptionConfig;
-  argumentOptions: OptionConfig;
-  /** Command class location */
-  location?: string;
-
-  /** child commands */
-  childs: ParsedCommand[];
-  /** parent command */
-  parent: ParsedCommand | null;
-  /** inherit command */
-  inherit: ParsedCommand | null;
-
-  commandConfig: CommandConfig;
-  commandMiddlewares: Middlewares;
-  executionMiddlewares: Middlewares;
-
-  constructor(public clz: typeof Command, option: ParsedCommandOption) {
-    const { location, commandConfig, parsedCommandInfo, optionConfig } = option;
-    this.location = location;
-
-    // read from parsed_command
-    this.uid = parsedCommandInfo.uid;
-    this.command = parsedCommandInfo.command;
-    this.cmd = parsedCommandInfo.cmd;
-    this.cmds = parsedCommandInfo.cmds;
-    this.demanded = parsedCommandInfo.demanded;
-    this.optional = parsedCommandInfo.optional;
-
-    // read from option config
-    this.flagOptions = optionConfig?.flagOptions || {};
-    this.argumentOptions = optionConfig?.argumentOptions || {};
-    this.childs = [];
-    this.parent = null;
-    this.inherit = null;
-
-    // read from command config
-    this.commandConfig = commandConfig;
-    this.description = commandConfig.description || '';
-    this.examples = formatToArray(commandConfig.examples);
-    this.enable = typeof commandConfig.enable === 'boolean' ? commandConfig.enable : true;
-    this.alias = formatToArray(commandConfig.alias);
-
-    // middleware config
-    this.commandMiddlewares = [];
-    this.executionMiddlewares = [];
-  }
-
-  get options(): OptionConfig {
-    if (!this[OPTION_SYMBOL]) {
-      this[OPTION_SYMBOL] = { ...this.globalOptions, ...this.flagOptions };
-    }
-    return this[OPTION_SYMBOL];
-  }
-
-  get isRoot() {
-    return !this.parent;
-  }
-
-  get isRunable() {
-    return this.clz !== EmptyCommand && this.enable;
-  }
-
-  get depth() {
-    return this.cmds.length;
-  }
-
-  addMiddlewares(type: 'command' | 'execution', config: MiddlewareConfig) {
-    const { middleware, mergeType } = config;
-    const middlewares = type === 'command' ? this.commandMiddlewares : this.executionMiddlewares;
-    const extraMiddlewares = Array.isArray(middleware) ? middleware : [ middleware ];
-    // mergeType default is after
-    if (!mergeType || mergeType === 'after') {
-      middlewares.push(...extraMiddlewares);
-    } else {
-      middlewares.unshift(...extraMiddlewares);
-    }
-  }
-
-  updateGlobalOptions(opt: OptionConfig) {
-    this.globalOptions = { ...this.globalOptions, ...opt };
-    this[OPTION_SYMBOL] = null;
-  }
-}
-
-/** Parsed Command Tree */
-export class ParsedCommandTree {
-  /** root of command tree */
-  root: ParsedCommand;
-
-  /** command list, the key is command string used to match argv */
-  commands: Map<string, ParsedCommand>;
-
-  /** cache the instance of parsedCommand */
-  parsedCommandMap: Map<typeof Command, ParsedCommand>;
-
-  constructor(
-    private binName: string,
-    private commandList: (typeof Command)[],
-  ) {
-    this.build();
-  }
-
-  /** convert Command class to ParsedCommand instance */
-  private initParsedCommand(clz: typeof Command) {
-    const metadata = Reflect.getOwnMetadata(MetadataEnum.COMMAND, clz) as CommandMeta;
-    if (!metadata) return null;
-
-    const commandMeta = metadata;
-    const inheritClass = Object.getPrototypeOf(clz);
-    const inheritCommand = this.initParsedCommand(inheritClass);
-
-    let commandConfig = { ...commandMeta.config };
-
-    // mege command config with inherit command
-    if (inheritCommand && commandMeta.inheritMetadata !== false) {
-      const inheritCommandConfig = inheritCommand.commandConfig;
-      commandConfig = Object.assign({}, {
-        alias: inheritCommandConfig.alias,
-        command: inheritCommandConfig.command,
-        description: inheritCommandConfig.description,
-        parent: inheritCommandConfig.parent,
-      } satisfies CommandConfig, commandConfig);
-    }
-
-    // default command is main command
-    commandConfig.command = commandConfig.command || '$0';
-
-    // init parent
-    let command = commandConfig.command!;
-    if (commandConfig.parent) {
-      const parentParsedCommand = this.initParsedCommand(commandConfig.parent);
-      assert(parentParsedCommand, `parent ${commandConfig.parent?.name} is not a valid Command`);
-      command = parentParsedCommand!.cmds.concat(command).join(' ');
-    }
-
-    // avoid creating parsedCommand again.
-    if (this.parsedCommandMap.has(clz)) {
-      return this.parsedCommandMap.get(clz);
-    }
-
-    // parse command usage
-    const parsedCommandInfo = parseCommand(command, this.binName);
-
-    // split options with argument key and merge option info with inherit command
-    const optionMeta: OptionMeta | undefined = Reflect.getOwnMetadata(MetadataEnum.OPTION, clz);
-    const argumentsKey = parsedCommandInfo.demanded.concat(parsedCommandInfo.optional).map(pos => pos.cmd);
-    let flagOptions: OptionConfig = omit(optionMeta?.config || {}, argumentsKey);
-    let argumentOptions: OptionConfig = pick(optionMeta?.config || {}, argumentsKey);
-    if (inheritCommand && optionMeta?.inheritMetadata !== false) {
-      flagOptions = Object.assign({}, inheritCommand.flagOptions, flagOptions);
-      argumentOptions = Object.assign({}, inheritCommand.argumentOptions, argumentOptions);
-    }
-
-    const parsedCommand = new ParsedCommand(clz, {
-      location: commandMeta.location,
-      commandConfig,
-      parsedCommandInfo,
-      optionConfig: { flagOptions, argumentOptions },
-    });
-
-    if (inheritCommand) parsedCommand.inherit = inheritCommand;
-    if (this.commands.has(parsedCommandInfo.uid)) {
-      const existsParsedCommand = this.commands.get(parsedCommandInfo.uid)!;
-
-      // override only allow in class inheritance or options.override=true
-      const err = errors.command_is_conflict(existsParsedCommand.command, existsParsedCommand.clz.name, existsParsedCommand.location, parsedCommand.clz.name, parsedCommand.location);
-      if (!commandMeta.overrideCommand && !isInheritFrom(parsedCommand.clz, existsParsedCommand.clz)) {
-        throw err;
-      }
-
-      debug(err.message);
-    }
-
-    // handle middlewares
-    // Default orders:
-    //
-    // In class inheritance:
-    //              command1  <-extend-  command2
-    // trigger --> middleware1   -->   middleware2 --> middleware3  --> run
-    //
-    // ------------
-    //
-    // In run method:
-    //                      command2                               command1
-    // trigger --> middleware2 --> middleware3 --> run --> middleware1 --> super.run
-
-    // merge command middlewares with inherit command
-    const middlewareMeta = Reflect.getOwnMetadata(MetadataEnum.MIDDLEWARE, clz) as (MiddlewareMeta | undefined);
-    const commandMiddlewareConfigList = middlewareMeta?.configList || [];
-    if (inheritCommand && middlewareMeta?.inheritMetadata !== false) {
-      parsedCommand.addMiddlewares('command', { middleware: inheritCommand.commandMiddlewares });
-    }
-    commandMiddlewareConfigList.forEach(config => parsedCommand.addMiddlewares('command', config));
-
-    // add run middlewares, no need to merge with inherit command
-    const executionMiddlewareConfig = Reflect.getOwnMetadata(MetadataEnum.RUN_MIDDLEWARE, clz) as (MiddlewareMeta | undefined);
-    const executionMiddlewareConfigList = executionMiddlewareConfig?.configList || [];
-    executionMiddlewareConfigList.forEach(config => parsedCommand.addMiddlewares('execution', config));
-
-    // cache the instance
-    this.commands.set(parsedCommandInfo.uid, parsedCommand);
-    this.parsedCommandMap.set(clz, parsedCommand);
-    return parsedCommand;
-  }
-
-  private build() {
-    this.commands = new Map();
-    this.parsedCommandMap = new Map();
-    const parsedCommands = this.commandList
-      .map(clz => this.initParsedCommand(clz))
-      .filter(c => !!c) as ParsedCommand[];
-
-    // handle parent and childs
-    parsedCommands
-      .sort((a, b) => a.depth - b.depth)
-      .forEach(parsedCommand => {
-        let parent: ParsedCommand | undefined;
-        parsedCommand.cmds.forEach(cmd => {
-          // fullCmd is the key of this.commands
-          const fullCmd = parent ? parent.cmds.concat(cmd).join(' ') : cmd;
-
-          let cacheParsedCommand = this.commands.get(fullCmd);
-          if (!cacheParsedCommand) {
-            // create empty node
-            debug('Create empty command for \'%s\'', fullCmd);
-            cacheParsedCommand = new ParsedCommand(EmptyCommand, {
-              commandConfig: {},
-              parsedCommandInfo: parseCommand(fullCmd, this.binName),
-            });
-            this.commands.set(fullCmd, cacheParsedCommand);
-          }
-
-          if (!parent) {
-            this.root = parent = cacheParsedCommand;
-            return;
-          }
-
-          cacheParsedCommand.parent = parent;
-          parent.childs.push(cacheParsedCommand);
-          parent = cacheParsedCommand;
-        });
-      });
-  }
-
-  get(clz: typeof Command) {
-    return this.parsedCommandMap.get(clz);
-  }
-}
-
 @Injectable({ scope: ScopeEnum.SINGLETON })
 export class ParsedCommands {
   @Inject()
@@ -324,13 +42,15 @@ export class ParsedCommands {
   get tree(): ParsedCommandTree {
     if (!this[TREE_SYMBOL]) {
       const commandList = this.container.getInjectableByTag(MetadataEnum.COMMAND);
-      this[TREE_SYMBOL] = new ParsedCommandTree(this.binInfo.binName, commandList);
+      const tree = this.container.get(ParsedCommandTree);
+      tree.build(commandList);
+      this[TREE_SYMBOL] = tree;
     }
     return this[TREE_SYMBOL];
   }
 
   get root() {
-    return this.tree.root;
+    return this.tree.root!;
   }
 
   get commands() {

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -147,11 +147,7 @@ export function parseCommand(cmd: string, binName: string) {
   const splitCommand = extraSpacesStrippedCommand.split(/\s+(?![^[]*]|[^<]*>)/);
   const bregex = /\.*[\][<>]\.*/g;
   if (!splitCommand.length) throw new Error(`No command found in: ${cmd}`);
-
-  // first cmd is binName or $0, remove it anyway
-  if ([ binName, '$0' ].includes(splitCommand[0])) {
-    splitCommand.shift();
-  }
+  if (splitCommand[0] === binName) splitCommand.shift();
 
   let command: string;
   if (!splitCommand[0] || splitCommand[0].match(bregex)) {

--- a/src/core/program.ts
+++ b/src/core/program.ts
@@ -7,7 +7,8 @@ import { CommandTrigger } from './trigger';
 import { OptionProps, MiddlewareInput, MiddlewareConfig } from '../types';
 import { Command } from './command';
 import { BinInfo } from './bin_info';
-import { ParsedCommand, ParsedCommands } from './parsed_commands';
+import { ParsedCommands } from './parsed_commands';
+import { ParsedCommand } from './parsed_command';
 
 type MaybeParsedCommand = (typeof Command) | ParsedCommand;
 

--- a/src/core/trigger.ts
+++ b/src/core/trigger.ts
@@ -5,7 +5,7 @@ import { Trigger, Injectable, ScopeEnum } from '@artus/core';
 import { Context, Output } from '@artus/pipeline';
 import { EXCUTION_SYMBOL } from '../constant';
 import { CommandContext, CommandInput, CommandOutput } from './context';
-import { ParsedCommand } from './parsed_commands';
+import { ParsedCommand } from './parsed_command';
 
 const debug = debuglog('artus-cli#trigger');
 

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable, ScopeEnum } from '@artus/core';
-import { ParsedCommand, ParsedCommands } from './parsed_commands';
+import { ParsedCommands } from './parsed_commands';
+import { ParsedCommand } from './parsed_command';
 import { Command } from './command';
 import { COMMAND_OPTION_SYMBOL } from '../constant';
 import { CommandContext } from './context';

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,8 @@ export * from './types';
 export * from './core/command';
 export * from './core/context';
 export * from './core/parsed_commands';
+export * from './core/parsed_command';
+export * from './core/parsed_command_tree';
 
 export async function start(options: ArtusCliOptions = {}) {
   if (process.env.ARTUS_CLI_SCANNING) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export interface CommandConfig extends Record<string, any> {
   /** command description */
   description?: string;
   /** command usage examples */
-  examples?: string | string[];
+  examples?: Array<string | [ string ] | [ string, string ]>;
   /** command alias */
   alias?: string | string[];
   /** parent command */
@@ -113,4 +113,9 @@ export interface ArtusCliConfig {
 
   /** strict mode in checking arguments, default is `options.strict` */
   strictCommands?: boolean;
+}
+
+export interface ExampleItem {
+  command: string;
+  description?: string;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { ParsedCommand } from './core/parsed_commands';
+import { ParsedCommand } from './core/parsed_command';
 import { Positional } from './core/parser';
 import pkgUp from 'pkg-up';
 import path from 'node:path';
@@ -94,4 +94,29 @@ export function formatToArray<T>(input?: T | T[]): T[] {
       ? input
       : [ input ]
     : [];
+}
+
+export function formatCmd(
+  cmd: string,
+  obj: Record<string, any> & { $0: string },
+  prefix?: string,
+) {
+  cmd = formatDesc(
+    cmd.trim().replace(/^\$0( |$)/, `${obj.$0}$1`),
+    obj,
+  );
+
+  if (prefix) {
+    if (cmd.startsWith(obj.$0)) {
+      return `${prefix} ${cmd.substring(obj.$0.length).trim()}`;
+    } else {
+      return `${prefix} ${cmd}`;
+    }
+  }
+
+  return cmd || obj.$0;
+}
+
+export function formatDesc(info: string, obj: Record<string, any>) {
+  return info.replace(/\{\{\s*(\w+)\s*\}\}/g, (_, key) => obj[key]);
 }

--- a/test/core/parsed_command_tree.test.ts
+++ b/test/core/parsed_command_tree.test.ts
@@ -14,11 +14,11 @@ describe('test/core/parsed_command_tree.test.ts', () => {
 
     @DefineCommand({
       command: 'dev [baseDir]',
-      description: '666',
+      description: '666 {{ name }} {{ version }}',
       examples: [
         'my-bin dev ./',
         [ '$0 dev ./' ],
-        [ '$0 dev ./', 'this is desc' ],
+        [ '$0 dev ./', 'show version {{ version }}' ],
       ],
     })
     @Middleware(async () => 1)
@@ -88,7 +88,7 @@ describe('test/core/parsed_command_tree.test.ts', () => {
     assert(parsedMyCommand.examples[0].command === 'my-bin dev ./');
     assert(parsedMyCommand.examples[1].command === 'argument-bin dev ./');
     assert(parsedMyCommand.examples[2].command === 'argument-bin dev ./');
-    assert(parsedMyCommand.examples[2].description === 'this is desc');
+    assert(parsedMyCommand.examples[2].description === 'show version 1.0.0');
     assert(parsedMyCommand.uid === 'argument-bin dev');
     assert(parsedMyCommand.clz === MyCommand);
     assert(parsedMyCommand.cmd === 'dev');
@@ -97,7 +97,7 @@ describe('test/core/parsed_command_tree.test.ts', () => {
     assert(parsedMyCommand.flagOptions.inspectPort.default === 8080);
     assert(!parsedMyCommand.flagOptions.baseDir);
     assert(parsedMyCommand.argumentOptions.baseDir);
-    assert(parsedMyCommand.description === '666');
+    assert(parsedMyCommand.description === '666 argument-bin 1.0.0');
     assert(parsedMyCommand.commandMiddlewares.length === 1);
     assert(parsedMyCommand.executionMiddlewares.length === 3);
 
@@ -105,7 +105,7 @@ describe('test/core/parsed_command_tree.test.ts', () => {
     assert(parsedNewMyCommand.location === __filename);
     assert(parsedNewMyCommand.clz === NewMyCommand);
     assert(parsedNewMyCommand.uid === 'argument-bin dev');
-    assert(parsedNewMyCommand.description === '666');
+    assert(parsedNewMyCommand.description === '666 argument-bin 1.0.0');
     assert(parsedNewMyCommand.flagOptions.port);
     assert(parsedNewMyCommand.flagOptions.inspectPort.default === 6666);
     assert(parsedNewMyCommand.argumentOptions.baseDir);

--- a/test/core/parsed_command_tree.test.ts
+++ b/test/core/parsed_command_tree.test.ts
@@ -1,0 +1,141 @@
+import { ArtusApplication } from '@artus/core';
+import { ParsedCommandTree, DefineCommand, Options, Middleware, Command } from '@artus-cli/artus-cli';
+import { createApp } from '../test-utils';
+import assert from 'node:assert';
+
+describe('test/core/parsed_command_tree.test.ts', () => {
+  let app: ArtusApplication;
+ 
+  afterEach(() => app && app.close());
+
+  it('should parsed tree works without error', async () => {
+    const beforeFn = async () => 1;
+    const afterFn = async () => 1;
+
+    @DefineCommand({
+      command: 'dev [baseDir]',
+      description: '666',
+      examples: [
+        'my-bin dev ./',
+        [ '$0 dev ./' ],
+        [ '$0 dev ./', 'this is desc' ],
+      ],
+    })
+    @Middleware(async () => 1)
+    class MyCommand extends Command {
+      @Options({
+        port: {},
+        inspectPort: { default: 8080 },
+        baseDir: {},
+      })
+      options: any;
+    
+      @Middleware(async () => 1)
+      @Middleware(async () => 1)
+      @Middleware(async () => 1)
+      async run() {
+        // nothing
+      }
+    }
+    
+    @DefineCommand()
+    @Middleware([ async () => 1, afterFn ])
+    @Middleware([ beforeFn ], { mergeType: 'before' })
+    class NewMyCommand extends MyCommand {
+      @Options({
+        inspectPort: { default: 6666 },
+      })
+      argv: any;
+    
+      async run() {
+        // nothing
+      }
+    }
+
+    function NewDefineCommand(...args: any[]) {
+      return DefineCommand(...args);
+    }
+
+    @NewDefineCommand({ command: 'aa' }, { inheritMetadata: false })
+    @Middleware([ async () => 1, async () => 1 ], { inheritMetadata: false })
+    class OverrideMyCommand extends MyCommand {
+      async run() {
+        // nothing
+      }
+    }
+
+    @DefineCommand({ command: 'aa' })
+    class ConflicMyCommand extends MyCommand {
+      async run() {
+        // nothing
+      }
+    }
+
+    @DefineCommand({ command: 'aa' }, { overrideCommand: true })
+    class NotConflicMyCommand extends MyCommand {
+      async run() {
+        // nothing
+      }
+    }
+  
+    app = await createApp('argument-bin');
+    const tree = app.container.get(ParsedCommandTree);
+
+    tree.build([ MyCommand, NewMyCommand, OverrideMyCommand ]);
+    const parsedMyCommand = tree.get(MyCommand)!;
+    assert(parsedMyCommand.location === __filename);
+    assert(parsedMyCommand.examples.length === 3);
+    assert(parsedMyCommand.examples[0].command === 'my-bin dev ./');
+    assert(parsedMyCommand.examples[1].command === 'argument-bin dev ./');
+    assert(parsedMyCommand.examples[2].command === 'argument-bin dev ./');
+    assert(parsedMyCommand.examples[2].description === 'this is desc');
+    assert(parsedMyCommand.uid === 'argument-bin dev');
+    assert(parsedMyCommand.clz === MyCommand);
+    assert(parsedMyCommand.cmd === 'dev');
+
+    assert(parsedMyCommand.flagOptions.port);
+    assert(parsedMyCommand.flagOptions.inspectPort.default === 8080);
+    assert(!parsedMyCommand.flagOptions.baseDir);
+    assert(parsedMyCommand.argumentOptions.baseDir);
+    assert(parsedMyCommand.description === '666');
+    assert(parsedMyCommand.commandMiddlewares.length === 1);
+    assert(parsedMyCommand.executionMiddlewares.length === 3);
+
+    const parsedNewMyCommand = tree.get(NewMyCommand)!;
+    assert(parsedNewMyCommand.location === __filename);
+    assert(parsedNewMyCommand.clz === NewMyCommand);
+    assert(parsedNewMyCommand.uid === 'argument-bin dev');
+    assert(parsedNewMyCommand.description === '666');
+    assert(parsedNewMyCommand.flagOptions.port);
+    assert(parsedNewMyCommand.flagOptions.inspectPort.default === 6666);
+    assert(parsedNewMyCommand.argumentOptions.baseDir);
+    assert(parsedNewMyCommand.commandMiddlewares.length === 4);
+    assert(parsedNewMyCommand.commandMiddlewares[0] === beforeFn);
+    assert(parsedNewMyCommand.commandMiddlewares[3] === afterFn);
+    assert(!parsedNewMyCommand.executionMiddlewares.length);
+
+    const parsedOverrideMyCommand = tree.get(OverrideMyCommand)!;
+    assert(parsedOverrideMyCommand.location === __filename);
+    assert(parsedOverrideMyCommand.clz === OverrideMyCommand);
+    assert(parsedOverrideMyCommand.uid === 'argument-bin aa');
+    assert(!parsedOverrideMyCommand.description);
+    assert(parsedOverrideMyCommand.commandMiddlewares.length === 2);
+    assert(!parsedOverrideMyCommand.executionMiddlewares.length);
+
+    // should conflict
+    assert.throws(() => {
+      tree.build([ MyCommand, NewMyCommand, OverrideMyCommand, ConflicMyCommand ]);
+    }, (e: Error) => {
+      assert(e.message.includes('Command \'aa\' is conflict in OverrideMyCommand('));
+      assert(e.message.includes('parsed_command_tree.test.ts'));
+      assert(e.message.includes('ConflicMyCommand('));
+      return true;
+    });
+
+    // should not confict
+    tree.build([ MyCommand, NewMyCommand, OverrideMyCommand, NotConflicMyCommand ]);
+    const notConflictCommand = tree.commands.get('argument-bin aa');
+    assert(tree.commands.size === 3);
+    assert(notConflictCommand?.clz === NotConflicMyCommand);
+  });
+});

--- a/test/core/parsed_commands.test.ts
+++ b/test/core/parsed_commands.test.ts
@@ -1,7 +1,7 @@
 import { ArtusApplication } from '@artus/core';
 import { DevCommand, DebugCommand, MainCommand } from 'egg-bin';
 import { ArgumentMainComand } from 'argument-bin';
-import { ErrorCode, ParsedCommandTree, DefineCommand, Options, Middleware, ParsedCommands, Program, EmptyCommand, Command } from '@artus-cli/artus-cli';
+import { ErrorCode, ParsedCommands, Program, EmptyCommand } from '@artus-cli/artus-cli';
 import { createApp } from '../test-utils';
 import assert from 'node:assert';
 import path from 'node:path';
@@ -197,126 +197,5 @@ describe('test/core/parsed_commands.test.ts', () => {
     assert(result2.matched === cmd);
     assert(result2.args.port === 666);
     assert(result2.args.inspect === true);
-  });
-
-  it('should parsed tree works without error', async () => {
-    const beforeFn = async () => 1;
-    const afterFn = async () => 1;
-
-    @DefineCommand({
-      command: 'dev [baseDir]',
-      description: '666',
-      examples: [
-        'my-bin dev ./',
-      ],
-    })
-    @Middleware(async () => 1)
-    class MyCommand extends Command {
-      @Options({
-        port: {},
-        inspectPort: { default: 8080 },
-        baseDir: {},
-      })
-      options: any;
-    
-      @Middleware(async () => 1)
-      @Middleware(async () => 1)
-      @Middleware(async () => 1)
-      async run() {
-        // nothing
-      }
-    }
-    
-    @DefineCommand()
-    @Middleware([ async () => 1, afterFn ])
-    @Middleware([ beforeFn ], { mergeType: 'before' })
-    class NewMyCommand extends MyCommand {
-      @Options({
-        inspectPort: { default: 6666 },
-      })
-      argv: any;
-    
-      async run() {
-        // nothing
-      }
-    }
-
-    function NewDefineCommand(...args: any[]) {
-      return DefineCommand(...args);
-    }
-
-    @NewDefineCommand({ command: 'aa' }, { inheritMetadata: false })
-    @Middleware([ async () => 1, async () => 1 ], { inheritMetadata: false })
-    class OverrideMyCommand extends MyCommand {
-      async run() {
-        // nothing
-      }
-    }
-
-    @DefineCommand({ command: 'aa' })
-    class ConflicMyCommand extends MyCommand {
-      async run() {
-        // nothing
-      }
-    }
-
-    @DefineCommand({ command: 'aa' }, { overrideCommand: true })
-    class NotConflicMyCommand extends MyCommand {
-      async run() {
-        // nothing
-      }
-    }
-  
-    const tree = new ParsedCommandTree('my-bin', [ MyCommand, NewMyCommand, OverrideMyCommand ]);
-    const parsedMyCommand = tree.get(MyCommand)!;
-    assert(parsedMyCommand.location === __filename);
-    assert(parsedMyCommand.examples[0] === 'my-bin dev ./');
-    assert(parsedMyCommand.uid === 'my-bin dev');
-    assert(parsedMyCommand.clz === MyCommand);
-    assert(parsedMyCommand.cmd === 'dev');
-    assert(parsedMyCommand.flagOptions.port);
-    assert(parsedMyCommand.flagOptions.inspectPort.default === 8080);
-    assert(!parsedMyCommand.flagOptions.baseDir);
-    assert(parsedMyCommand.argumentOptions.baseDir);
-    assert(parsedMyCommand.description === '666');
-    assert(parsedMyCommand.commandMiddlewares.length === 1);
-    assert(parsedMyCommand.executionMiddlewares.length === 3);
-
-    const parsedNewMyCommand = tree.get(NewMyCommand)!;
-    assert(parsedNewMyCommand.location === __filename);
-    assert(parsedNewMyCommand.clz === NewMyCommand);
-    assert(parsedNewMyCommand.uid === 'my-bin dev');
-    assert(parsedNewMyCommand.description === '666');
-    assert(parsedNewMyCommand.flagOptions.port);
-    assert(parsedNewMyCommand.flagOptions.inspectPort.default === 6666);
-    assert(parsedNewMyCommand.argumentOptions.baseDir);
-    assert(parsedNewMyCommand.commandMiddlewares.length === 4);
-    assert(parsedNewMyCommand.commandMiddlewares[0] === beforeFn);
-    assert(parsedNewMyCommand.commandMiddlewares[3] === afterFn);
-    assert(!parsedNewMyCommand.executionMiddlewares.length);
-
-    const parsedOverrideMyCommand = tree.get(OverrideMyCommand)!;
-    assert(parsedOverrideMyCommand.location === __filename);
-    assert(parsedOverrideMyCommand.clz === OverrideMyCommand);
-    assert(parsedOverrideMyCommand.uid === 'my-bin aa');
-    assert(!parsedOverrideMyCommand.description);
-    assert(parsedOverrideMyCommand.commandMiddlewares.length === 2);
-    assert(!parsedOverrideMyCommand.executionMiddlewares.length);
-
-    // should conflict
-    assert.throws(() => {
-      new ParsedCommandTree('my-bin', [ MyCommand, NewMyCommand, OverrideMyCommand, ConflicMyCommand ]);
-    }, (e: Error) => {
-      assert(e.message.includes('Command \'aa\' is conflict in OverrideMyCommand('));
-      assert(e.message.includes('parsed_commands.test.ts'));
-      assert(e.message.includes('ConflicMyCommand('));
-      return true;
-    });
-
-    // should not confict
-    const tree2 = new ParsedCommandTree('my-bin', [ MyCommand, NewMyCommand, OverrideMyCommand, NotConflicMyCommand ]);
-    const notConflictCommand = tree2.commands.get('my-bin aa');
-    assert(tree2.commands.size === 3);
-    assert(notConflictCommand?.clz === NotConflicMyCommand);
   });
 });

--- a/test/core/parser.test.ts
+++ b/test/core/parser.test.ts
@@ -20,7 +20,7 @@ describe('test/core/parser.test.ts', () => {
     assert(r3.optional.length === 0);
     assert(r3.demanded.length === 0);
 
-    const r4 = parseCommand('$0 dev', 'my-bin');
+    const r4 = parseCommand('my-bin dev', 'my-bin');
     assert.deepEqual(r4.cmds, ['my-bin', 'dev']);
   });
 

--- a/test/fixtures/argument-bin/package.json
+++ b/test/fixtures/argument-bin/package.json
@@ -1,5 +1,6 @@
 {
   "name": "argument-bin",
+  "version": "1.0.0",
   "type": "commonjs",
   "bin": "./index.js"
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,5 @@
 import { ArtusApplication } from '@artus/core';
-import { checkCommandCompatible, isInheritFrom, isNil, readPkg, getCalleeList, getCalleeDir } from '../src/utils';
+import { checkCommandCompatible, isInheritFrom, isNil, readPkg, getCalleeList, getCalleeDir, formatCmd, formatDesc } from '../src/utils';
 import { DevCommand, DebugCommand, MainCommand } from 'egg-bin';
 import { ParsedCommands, Command } from '@artus-cli/artus-cli';
 import path from 'node:path';
@@ -45,5 +45,29 @@ describe('test/utils.test.ts', () => {
     assert(getCalleeList(3)[0].fileName);
     assert.equal(getCalleeDir(1), __dirname);
     assert(getCalleeDir(2)?.includes('mocha'));
+  });
+
+  it('formatCommand', async () => {
+    const obj = {
+      $0: 'my-bin',
+      bin: 'my-bin',
+    };
+
+    assert(formatCmd('$0 dev', obj), 'my-bin dev');
+    assert(formatCmd(' $0 dev', obj), 'my-bin dev');
+    assert(formatCmd(' $0', obj), 'my-bin');
+    assert(formatCmd('other-bin', obj), 'other-bin');
+    assert(formatCmd('{{ bin }}', obj), 'my-bin');
+    assert(formatCmd('test {{ bin }}', obj), 'test my-bin');
+  });
+
+  it('formatDesc', async () => {
+    const obj = {
+      $0: 'my-bin',
+      bin: 'my-bin',
+    };
+
+    assert(formatDesc('dev {{ $0 }}', obj), 'dev my-bin');
+    assert(formatDesc('{{ bin }} dev', obj), 'my-bin dev');
   });
 });


### PR DESCRIPTION
- 将 parse_commands 的逻辑拆分出来（ 原来揉在一块 ）
- 优化了对 `$0` 的处理，包括 examples （ 格式改成跟 yargs 一致 ）