### PR TITLE
fix: property initialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artus-cli/artus-cli",
-  "version": "0.2.7",
+  "version": "0.2.8-beta",
   "description": "CLI framework with modern features",
   "homepage": "https://github.com/artus-cli/artus-cli",
   "author": "TZ <atian25@qq.com>",

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -5,7 +5,11 @@ export enum MetadataEnum {
   RUN_MIDDLEWARE = 'RUN_MIDDLEWARE_METADATA'
 }
 
+export enum OptionInjectType {
+  KEY_OPTION,
+  FULL_OPTION,
+}
+
 export const CONTEXT_SYMBOL = Symbol('Command#Context');
 export const EXCUTION_SYMBOL = Symbol('Command#Excution');
 export const BIN_OPTION_SYMBOL = Symbol('BinInfo#Option');
-export const COMMAND_OPTION_SYMBOL = Symbol('Command#Option');

--- a/src/core/command.ts
+++ b/src/core/command.ts
@@ -5,7 +5,7 @@ export abstract class Command {
   '_': string[];
 
   /** Arguments after the end-of-options flag `--` */
-  '--': string[];
+  '--'?: string[];
 
   abstract run(...args: any[]): Promise<any>;
 }

--- a/src/core/command.ts
+++ b/src/core/command.ts
@@ -1,16 +1,11 @@
 import { Injectable } from '@artus/core';
-import { COMMAND_OPTION_SYMBOL } from '../constant';
 
 export abstract class Command {
   /** Non-option arguments */
-  get _() {
-    return this[COMMAND_OPTION_SYMBOL]._;
-  }
+  '_': string[];
 
   /** Arguments after the end-of-options flag `--` */
-  get '--'() {
-    return this[COMMAND_OPTION_SYMBOL]['--'];
-  }
+  '--': string[];
 
   abstract run(...args: any[]): Promise<any>;
 }

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -33,8 +33,8 @@ export class CommandContext<
 
   env: Record<string, string | undefined>;
   cwd: string;
-  input: CommandInput;
-  output: CommandOutput<OutputResult>;
+  declare input: CommandInput;
+  declare output: CommandOutput<OutputResult>;
 
   init() {
     const params = this.input.params;

--- a/src/core/parsed_command.ts
+++ b/src/core/parsed_command.ts
@@ -2,7 +2,6 @@ import { Middlewares } from '@artus/pipeline';
 import { CommandConfig, OptionConfig, MiddlewareConfig, ExampleItem, OptionInjectMeta, OptionMeta } from '../types';
 import { ParsedCommandStruct, Positional } from './parser';
 import { Command, EmptyCommand } from './command';
-import { OptionInjectType } from '../constant';
 const OPTION_SYMBOL = Symbol('ParsedCommand#Option');
 
 export interface ParsedCommandOption {
@@ -72,11 +71,7 @@ export class ParsedCommand implements ParsedCommandStruct {
     this.optional = parsedCommandInfo.optional;
 
     // read from option config
-    this.injections = (optionConfig?.injections || []).concat([
-      // default option in args
-      { propName: '_', type: OptionInjectType.KEY_OPTION },
-      { propName: '--', type: OptionInjectType.KEY_OPTION },
-    ]);
+    this.injections = optionConfig?.injections || [];
     this.flagOptions = optionConfig?.flagOptions || {};
     this.argumentOptions = optionConfig?.argumentOptions || {};
     this.childs = [];

--- a/src/core/parsed_command.ts
+++ b/src/core/parsed_command.ts
@@ -1,13 +1,14 @@
 import { Middlewares } from '@artus/pipeline';
-import { CommandConfig, OptionConfig, MiddlewareConfig, ExampleItem } from '../types';
+import { CommandConfig, OptionConfig, MiddlewareConfig, ExampleItem, OptionInjectMeta, OptionMeta } from '../types';
 import { ParsedCommandStruct, Positional } from './parser';
 import { Command, EmptyCommand } from './command';
+import { OptionInjectType } from '../constant';
 const OPTION_SYMBOL = Symbol('ParsedCommand#Option');
 
 export interface ParsedCommandOption {
   location?: string;
   commandConfig: FormattedCommandConfig;
-  optionConfig?: {
+  optionConfig?: Partial<OptionMeta> & {
     flagOptions: OptionConfig;
     argumentOptions: OptionConfig;
   };
@@ -40,6 +41,7 @@ export class ParsedCommand implements ParsedCommandStruct {
   description: string;
   examples: ExampleItem[];
   globalOptions?: OptionConfig;
+  injections: OptionInjectMeta[];
   flagOptions: OptionConfig;
   argumentOptions: OptionConfig;
   /** Command class location */
@@ -70,6 +72,11 @@ export class ParsedCommand implements ParsedCommandStruct {
     this.optional = parsedCommandInfo.optional;
 
     // read from option config
+    this.injections = (optionConfig?.injections || []).concat([
+      // default option in args
+      { propName: '_', type: OptionInjectType.KEY_OPTION },
+      { propName: '--', type: OptionInjectType.KEY_OPTION },
+    ]);
     this.flagOptions = optionConfig?.flagOptions || {};
     this.argumentOptions = optionConfig?.argumentOptions || {};
     this.childs = [];

--- a/src/core/parsed_command_tree.ts
+++ b/src/core/parsed_command_tree.ts
@@ -4,7 +4,7 @@ import { Injectable, Inject, ScopeEnum } from '@artus/core';
 import { CommandMeta, CommandConfig, OptionMeta, OptionConfig, MiddlewareMeta } from '../types';
 import { parseCommand } from './parser';
 import { Command, EmptyCommand } from './command';
-import { MetadataEnum } from '../constant';
+import { MetadataEnum, OptionInjectType } from '../constant';
 import { isInheritFrom, formatToArray, formatCmd, formatDesc } from '../utils';
 import { errors } from '../errors';
 import { ParsedCommand, FormattedCommandConfig } from './parsed_command';
@@ -48,8 +48,16 @@ export class ParsedCommandTree {
       }
     });
 
+    const injections = optionMeta?.injections || [];
+    injections.push(
+      // default option in args
+      { propName: '_', type: OptionInjectType.KEY_OPTION },
+      { propName: '--', type: OptionInjectType.KEY_OPTION },
+    );
+
     return {
       ...optionMeta,
+      injections,
       flagOptions,
       argumentOptions,
     };

--- a/src/core/parsed_command_tree.ts
+++ b/src/core/parsed_command_tree.ts
@@ -1,6 +1,6 @@
 import { debuglog } from 'node:util';
 import assert from 'node:assert';
-import { Injectable, Inject, ScopeEnum, Container } from '@artus/core';
+import { Injectable, Inject, ScopeEnum } from '@artus/core';
 import { CommandMeta, CommandConfig, OptionMeta, OptionConfig, MiddlewareMeta } from '../types';
 import { parseCommand } from './parser';
 import { Command, EmptyCommand } from './command';
@@ -16,9 +16,6 @@ const debug = debuglog('artus-cli#ParsedCommands');
 export class ParsedCommandTree {
   @Inject()
   private readonly binInfo: BinInfo;
-
-  @Inject()
-  private container: Container;
 
   /** root of command tree */
   root: ParsedCommand | undefined;

--- a/src/core/trigger.ts
+++ b/src/core/trigger.ts
@@ -3,7 +3,7 @@ import { debuglog } from 'node:util';
 import { Trigger, Injectable, ScopeEnum } from '@artus/core';
 
 import { Context, Output } from '@artus/pipeline';
-import { EXCUTION_SYMBOL } from '../constant';
+import { EXCUTION_SYMBOL, OptionInjectType } from '../constant';
 import { CommandContext, CommandInput, CommandOutput } from './context';
 import { ParsedCommand } from './parsed_command';
 
@@ -77,6 +77,14 @@ export class CommandTrigger extends Trigger {
   /** execute command in pipeline */
   async executeCommand(ctx: CommandContext, cmd: ParsedCommand) {
     const instance = ctx.container.get(cmd.clz);
+    cmd.injections.forEach(info => {
+      if (info.type === OptionInjectType.FULL_OPTION) {
+        instance[info.propName] = ctx.args;
+      } else {
+        const assignValue = ctx.args[info.propName];
+        if (assignValue !== undefined) instance[info.propName] = assignValue;
+      }
+    });
     if (instance[EXCUTION_SYMBOL]) await instance[EXCUTION_SYMBOL]();
     return ctx.output.data;
   }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -2,7 +2,6 @@ import { Inject, Injectable, ScopeEnum } from '@artus/core';
 import { ParsedCommands } from './parsed_commands';
 import { ParsedCommand } from './parsed_command';
 import { Command } from './command';
-import { COMMAND_OPTION_SYMBOL } from '../constant';
 import { CommandContext } from './context';
 import { CommandTrigger } from './trigger';
 import assert from 'node:assert';
@@ -19,12 +18,11 @@ export class Utils {
   @Inject()
   private readonly commands: ParsedCommands;
 
-  /** executing other command in same pipeline */
+  /** forward to other command in same pipeline */
   async forward<T extends Record<string, any> = Record<string, any>>(clz: typeof Command | ParsedCommand, args?: T) {
     const cmd = clz instanceof ParsedCommand ? clz : this.commands.getCommand(clz);
     assert(cmd, format('Can not forward to command %s', cmd?.clz.name));
-    const instance = this.ctx.container.get(cmd.clz);
-    if (args) instance[COMMAND_OPTION_SYMBOL] = args;
+    Object.assign(this.ctx.args, this.commands.parseArgs(this.ctx.raw, cmd).args, args);
     return this.trigger.executeCommand(this.ctx, cmd);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import { Command } from './core/command';
 import { Middleware, Middlewares } from '@artus/pipeline';
+import { OptionInjectType } from './constant';
 
 export interface CommandConfig extends Record<string, any> {
   /** whether enable command, default to true */
@@ -73,9 +74,15 @@ export interface BaseMeta {
   inheritMetadata?: boolean;
 }
 
+export interface OptionInjectMeta {
+  type: OptionInjectType;
+  propName: string;
+}
+
 export interface OptionMeta<T extends string = string> extends BaseMeta {
   /** option config */
   config: OptionConfig<T>;
+  injections: OptionInjectMeta[];
 }
 
 export interface CommandMeta extends BaseMeta {

--- a/test/core/decorators.test.ts
+++ b/test/core/decorators.test.ts
@@ -66,12 +66,12 @@ describe('test/core/decorators.test.ts', () => {
   it('Option/Options', async () => {
     const metadata: OptionMeta = Reflect.getOwnMetadata(MetadataEnum.OPTION, MyCommand);
     assert(metadata.config.port);
-    assert('args' in MyCommand.prototype);
+    assert(metadata.injections.find(info => info.propName === 'args'));
 
     // extend
     const metadata2: OptionMeta = Reflect.getOwnMetadata(MetadataEnum.OPTION, NewMyCommand);
     assert(metadata2.config);
-    assert('argv' in NewMyCommand.prototype);
+    assert(metadata2.injections.find(info => info.propName === 'argv'));
   });
 
   it('Middlware', async () => {

--- a/test/core/utils.test.ts
+++ b/test/core/utils.test.ts
@@ -25,6 +25,7 @@ describe('test/core/utils.test.ts', () => {
     });
 
     const { result } = await utils.forward(DebugCommand);
+    console.info(result);
     assert(result);
     assert(result.command === 'debug');
     assert(result.args.port === 3000);

--- a/test/core/utils.test.ts
+++ b/test/core/utils.test.ts
@@ -25,7 +25,6 @@ describe('test/core/utils.test.ts', () => {
     });
 
     const { result } = await utils.forward(DebugCommand);
-    console.info(result);
     assert(result);
     assert(result.command === 'debug');
     assert(result.args.port === 3000);

--- a/test/fixtures/assignprop/bin/cli.ts
+++ b/test/fixtures/assignprop/bin/cli.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+import path from 'path';
+import { start } from '@artus-cli/artus-cli';
+
+start({ baseDir: path.dirname(__dirname) });

--- a/test/fixtures/assignprop/cmd/main.ts
+++ b/test/fixtures/assignprop/cmd/main.ts
@@ -1,0 +1,21 @@
+// index.ts
+import { DefineCommand, Option, Command } from '@artus-cli/artus-cli';
+
+@DefineCommand({
+  command: '$0 [baseDir]',
+  description: 'My Simple Bin',
+})
+export class MainCommand extends Command {
+  @Option({
+    alias: 'p',
+    description: 'port',
+  })
+  port = 3000;
+
+  @Option()
+  baseDir = './';
+
+  async run() {
+    console.info('Run with port %s in %s', this.port, this.baseDir);
+  }
+}

--- a/test/fixtures/assignprop/config/plugin.ts
+++ b/test/fixtures/assignprop/config/plugin.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/test/fixtures/assignprop/package.json
+++ b/test/fixtures/assignprop/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "assignprop",
+  "type": "commonjs",
+  "bin": {
+    "simple": "./bin/cli.js"
+  }
+}

--- a/test/fixtures/egg-bin/cmd/cov.ts
+++ b/test/fixtures/egg-bin/cmd/cov.ts
@@ -1,4 +1,4 @@
-import { DefineCommand, Option, Command, Inject } from '@artus-cli/artus-cli';
+import { DefineCommand, Option, Command, Inject, Utils } from '@artus-cli/artus-cli';
 import { TestCommand } from './test';
 
 @DefineCommand({
@@ -10,10 +10,10 @@ export class CovCommand extends Command {
   c8: boolean;
 
   @Inject()
-  testCommand: TestCommand;
+  utils: Utils;
 
   async run() {
     console.info('coverage c8', this.c8);
-    return this.testCommand.run();
+    return this.utils.forward(TestCommand);
   }
 }

--- a/test/fixtures/egg-bin/cmd/dev.ts
+++ b/test/fixtures/egg-bin/cmd/dev.ts
@@ -38,6 +38,8 @@ export class DevCommand extends Command {
     console.info('inspect', this.inspect);
     console.info('nodeFlags', this.nodeFlags);
     console.info('baseDir', this.baseDir);
+    console.info('_', this._);
+    console.info('--', this['--']);
     return {
       command: 'dev',
       args: this.args,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -235,4 +235,21 @@ describe('test/index.test.ts', () => {
       .expect('stderr', /Command is not found: 'dynamic debug'/)
       .end();
   });
+
+  it('should assign prop in option', async () => {
+    await fork('assignprop')
+      // .debug()
+      .expect('stdout', /Run with port 3000 in \.\//)
+      .end();
+
+    await fork('assignprop', [ '--port', '8080' ])
+      // .debug()
+      .expect('stdout', /Run with port 8080 in \.\//)
+      .end();
+
+    await fork('assignprop', [ './test', '--port', '8080' ])
+      // .debug()
+      .expect('stdout', /Run with port 8080 in \.\/test/)
+      .end();
+  });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -20,6 +20,13 @@ describe('test/index.test.ts', () => {
       .expect('stdout', /inspect false/)
       .expect('stdout', /nodeFlags undefined/)
       .expect('stdout', /baseDir 123/)
+      .expect('stdout', /_ \[ 'dev', 123 \]/)
+      .expect('stdout', /-- undefined/)
+      .end();
+
+    await fork('egg-bin', [ 'dev', '123', '-p=6000', '--', '--other' ])
+      .debug()
+      .expect('stdout', /-- \[ '--other' \]/)
       .end();
 
     await fork('egg-bin', [ '-v' ])


### PR DESCRIPTION
修复有 `property initialization` 下装饰器不生效问题（ target 2022 默认有 property initialization ，所以稳定跪  ）

> 原来是在属性装饰器中通过 Object.defineProperty 给 prototype 加上注入的属性，由于有 `property initialization` 会覆盖该属性的读取导致注入不生效。现在改成在执行 Command 之前给实例赋值 