### PR TITLE
feat: move inherit metadata to DefineCommand

### DIFF
--- a/src/config/config.default.ts
+++ b/src/config/config.default.ts
@@ -3,6 +3,7 @@ import { ArtusCliConfig } from '../types';
 export default {
   // binName: 'xxx',
   strict: true,
+  inheritMetadata: true,
   // strictOptions: true,
   // strictCommands: true,
 } satisfies ArtusCliConfig;

--- a/src/core/bin_info.ts
+++ b/src/core/bin_info.ts
@@ -27,6 +27,7 @@ export class BinInfo {
   strict: boolean;
   strictCommands: boolean;
   strictOptions: boolean;
+  inheritMetadata: boolean;
 
   constructor(
     @Inject(ArtusInjectEnum.Application) app: ArtusApplication,
@@ -42,10 +43,13 @@ export class BinInfo {
     this.description = opt.pkgInfo.description || '';
     this.pkgInfo = opt.pkgInfo;
 
+    const config: ArtusCliConfig = app.config;
+    this.inheritMetadata = !!config.inheritMetadata;
+
     const getBool = (...args: any[]) => args.find(a => typeof a === 'boolean');
-    this.strict = getBool(opt.strict, app.config.strict);
-    this.strictCommands = getBool(opt.strictCommands, app.config.strictCommands, this.strict);
-    this.strictOptions = getBool(opt.strictOptions, app.config.strictOptions, this.strict);
+    this.strict = getBool(opt.strict, config.strict);
+    this.strictCommands = getBool(opt.strictCommands, config.strictCommands, this.strict);
+    this.strictOptions = getBool(opt.strictOptions, config.strictOptions, this.strict);
     delete app[BIN_OPTION_SYMBOL];
   }
 }

--- a/src/core/decorators.ts
+++ b/src/core/decorators.ts
@@ -5,11 +5,10 @@ import { CommandContext, CommandOutput } from './context';
 import compose from 'koa-compose';
 import { Command } from './command';
 import { getCalleeList } from '../utils';
-import { BaseMeta, MiddlewareMeta, MiddlewareInput, MiddlewareConfig, CommandConfig, OptionProps, OptionMeta, ConvertTypeToBasicType, CommandMeta } from '../types';
+import { MiddlewareMeta, MiddlewareInput, MiddlewareConfig, CommandConfig, OptionProps, OptionMeta, ConvertTypeToBasicType, CommandMeta } from '../types';
 
-export interface CommonDecoratorOption extends Pick<BaseMeta, 'inheritMetadata'> {}
-export interface MiddlewareDecoratorOption extends CommonDecoratorOption, Pick<MiddlewareConfig, 'mergeType'> {}
-export interface CommandDecoratorOption extends CommonDecoratorOption, Pick<CommandMeta, 'overrideCommand'> {}
+export interface MiddlewareDecoratorOption extends Pick<MiddlewareConfig, 'mergeType'> {}
+export interface CommandDecoratorOption extends Pick<CommandMeta, 'overrideCommand' | 'inheritMetadata'> {}
 
 export function DefineCommand(
   opt?: CommandConfig,
@@ -95,11 +94,6 @@ export function Middleware(fn: MiddlewareInput, option?: MiddlewareDecoratorOpti
       mergeType: option?.mergeType || 'after',
     });
 
-    if (typeof option?.inheritMetadata === 'boolean' && typeof existsMeta.inheritMetadata === 'boolean' && existsMeta.inheritMetadata !== option.inheritMetadata) {
-      throw new Error(`Can\'t use inheritMetadata in multiple @Middleware`);
-    }
-
-    existsMeta.inheritMetadata = option?.inheritMetadata;
     Reflect.defineMetadata(metaKey, existsMeta, ctor);
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ export interface MiddlewareConfig {
 
 export type MiddlewareInput = Middleware | Middlewares;
 
-export interface MiddlewareMeta extends BaseMeta {
+export interface MiddlewareMeta {
   /** middleware config list */
   configList: MiddlewareConfig[];
 }
@@ -69,29 +69,26 @@ export interface OptionProps<T extends BasicType = BasicType, G = any> extends R
 
 export type OptionConfig<T extends string = string> = Record<T, OptionProps>;
 
-export interface BaseMeta {
-  /** whether inherit meta data from prototype, default to true */
-  inheritMetadata?: boolean;
-}
-
 export interface OptionInjectMeta {
   type: OptionInjectType;
   propName: string;
 }
 
-export interface OptionMeta<T extends string = string> extends BaseMeta {
+export interface OptionMeta<T extends string = string> {
   /** option config */
   config: OptionConfig<T>;
   injections: OptionInjectMeta[];
 }
 
-export interface CommandMeta extends BaseMeta {
+export interface CommandMeta {
   /** command config */
   config: CommandConfig;
   /** Command Class location */
   location?: string;
   /** whether override exists conflict command */
   overrideCommand?: boolean;
+  /** whether inherit metadata from parent class( includes middleware, options ), default is true */
+  inheritMetadata?: boolean;
 }
 
 export interface ArtusCliOptions extends Partial<ArtusCliConfig> {
@@ -114,6 +111,9 @@ export interface ArtusCliOptions extends Partial<ArtusCliConfig> {
 export interface ArtusCliConfig {
   /** your bin name, default is name in package.json */
   binName?: string;
+
+  /** whether inherit command metadata */
+  inheritMetadata?: boolean;
 
   /** strict mode in checking arguments and options, default is true */
   strict?: boolean;

--- a/test/core/decorators.test.ts
+++ b/test/core/decorators.test.ts
@@ -92,11 +92,5 @@ describe('test/core/decorators.test.ts', () => {
     assert.throws(() => {
       Middleware(async () => 1)(new NewMyCommand(), 'other' as any);
     }, /Middleware can only be used in Command Class or run method/);
-
-    // should throw with multiple override
-    assert.throws(() => {
-      Middleware(async () => 1, { inheritMetadata: true })(NewMyCommand);
-      Middleware(async () => 1, { inheritMetadata: false })(NewMyCommand);
-    }, /Can\'t use inheritMetadata in multiple @Middleware/);
   });
 });

--- a/test/core/parsed_command_tree.test.ts
+++ b/test/core/parsed_command_tree.test.ts
@@ -57,7 +57,7 @@ describe('test/core/parsed_command_tree.test.ts', () => {
     }
 
     @NewDefineCommand({ command: 'aa' }, { inheritMetadata: false })
-    @Middleware([ async () => 1, async () => 1 ], { inheritMetadata: false })
+    @Middleware([ async () => 1, async () => 1 ])
     class OverrideMyCommand extends MyCommand {
       async run() {
         // nothing
@@ -120,6 +120,7 @@ describe('test/core/parsed_command_tree.test.ts', () => {
     assert(parsedOverrideMyCommand.uid === 'argument-bin aa');
     assert(!parsedOverrideMyCommand.description);
     assert(parsedOverrideMyCommand.commandMiddlewares.length === 2);
+    assert(Object.keys(parsedOverrideMyCommand.flagOptions).length === 0);
     assert(!parsedOverrideMyCommand.executionMiddlewares.length);
 
     // should conflict

--- a/test/fixtures/no-inherit/bin/cli.ts
+++ b/test/fixtures/no-inherit/bin/cli.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+import { start } from '@artus-cli/artus-cli';
+start();

--- a/test/fixtures/no-inherit/cmd/dev.ts
+++ b/test/fixtures/no-inherit/cmd/dev.ts
@@ -1,0 +1,18 @@
+import { DefineCommand, Middleware } from '@artus-cli/artus-cli';
+import { DevCommand as BaseDevCommand } from 'egg-bin';
+
+@DefineCommand({
+  command: 'dev',
+  description: 'Run the development server with chair-bin',
+})
+@Middleware(async (_ctx, next) => {
+  console.info('noinherit-bin dev command prerun');
+  await next();
+  console.info('noinherit-bin dev command postrun');
+})
+export class ChairDevCommand extends BaseDevCommand {
+  async run() {
+    console.info(super.run());
+    return {} as any;
+  }
+}

--- a/test/fixtures/no-inherit/config/config.ts
+++ b/test/fixtures/no-inherit/config/config.ts
@@ -1,0 +1,5 @@
+import { ArtusCliConfig } from "@artus-cli/artus-cli";
+
+export default {
+  inheritMetadata: false,
+} satisfies ArtusCliConfig;

--- a/test/fixtures/no-inherit/config/framework.ts
+++ b/test/fixtures/no-inherit/config/framework.ts
@@ -1,0 +1,5 @@
+import path from 'path';
+
+export default {
+  path: path.dirname(require.resolve('egg-bin')),
+};

--- a/test/fixtures/no-inherit/package.json
+++ b/test/fixtures/no-inherit/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "noinherit-bin",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "bin": "./bin/cli.js"
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -263,6 +263,22 @@ describe('test/index.test.ts', () => {
       .end();
   });
 
+  it('should not inherit metadata', async () => {
+    await fork('no-inherit', [ 'dev', '-h' ])
+      // .debug()
+      .notExpect('stdout', /--port/)
+      .notExpect('stdout', /--inspect/)
+      .notExpect('stdout', /--node-flags/)
+      .end();
+
+    await fork('no-inherit', [ 'dev' ])
+      // .debug()
+      .expect('stdout', /port undefined/)
+      .expect('stdout', /inspect undefined/)
+      .expect('stdout', /nodeFlags undefined/)
+      .end();
+  });
+
   describe('useManifestCache', () => {
     const cacheManifestPath = path.resolve(__dirname, './fixtures/cacheManifest/manifest.json');
     const clearManifest = () => fs.existsSync(cacheManifestPath) && fs.unlinkSync(cacheManifestPath);


### PR DESCRIPTION
原来 `inheritMetadata` 是放到了各个装饰器里，感觉很别扭，比如 Middleware 这种独立的控制是否允许继承，多个还得判断互斥，逻辑很奇怪。

现在改成统一在 `DefineCommand` 的参数里，通过 DefineCommand 可以控制该指令是否需要继承元数据。也可以在 config.ts 中配置全局策略 `{ inheritMetadata: true }` 。

> 之前担心没思考清楚，所以元数据继承配置并未在文档里提供，这次 break change 改掉问题也不大，毕竟也还没发正式版本

这个配置应该算是元数据是否要继承的定稿，可以上层 CLI 自己控制要不要支持元数据继承，默认是继承的。