### PR TITLE
fix: default add artus-cli plugin

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,12 @@ export async function start(options: ArtusCliOptions = {}) {
       configDir: 'config',
       extensions: [ '.ts' ],
       exclude,
+      plugin: {
+        artusCli: {
+          enable: true,
+          path: path.resolve(__dirname, './'),
+        },
+      },
     });
 
     manifest = await scanner.scan(baseDir);

--- a/test/fixtures/egg-bin/config/plugin.ts
+++ b/test/fixtures/egg-bin/config/plugin.ts
@@ -1,8 +1,1 @@
-import path from 'path';
-
-export default {
-  artusCli: {
-    enable: true,
-    path: path.dirname(require.resolve('@artus-cli/artus-cli')),
-  },    
-};
+export default {};


### PR DESCRIPTION
默认加上 artus-cli 插件并开启（ 就不用再配 config 了 ）